### PR TITLE
Fix empty translation file causing array_replace_recursive() error

### DIFF
--- a/resources/lang/en/flowforge.php
+++ b/resources/lang/en/flowforge.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    // Flowforge translation keys will be added here as needed
+];


### PR DESCRIPTION
- Replace empty resources/lang/en/flowforge.php with proper PHP array structure
- Prevents TypeError when Laravel Extra Intellisense or other tools load translation namespaces
- Maintains backwards compatibility while fixing development tool compatibility

Fixes issue where empty translation file returns null instead of array, causing array_replace_recursive() to fail in Laravel's translation loader.