### PR TITLE
Remove duplicate suffix on creating command

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Schema::table('tasks', function (Blueprint $table) {
 
 ### 3. Generate Board
 ```bash
-php artisan flowforge:make-board TaskBoard --model=Task
+php artisan flowforge:make-board Task --model=Task
 ```
 
 ### 4. Register Page


### PR DESCRIPTION
The creating command is already adding 'BoardPage' suffix :

$className = Str::studly($name) . 'BoardPage';