### PR TITLE
Fix: Add Filament v4 navigation property type declarations

### DIFF
--- a/src/BoardPage.php
+++ b/src/BoardPage.php
@@ -9,6 +9,8 @@ use Filament\Forms\Contracts\HasForms;
 use Filament\Pages\Page;
 use Relaticle\Flowforge\Concerns\BaseBoard;
 use Relaticle\Flowforge\Contracts\HasBoard;
+use UnitEnum;
+use BackedEnum;
 
 /**
  * Board page for standard Filament pages.
@@ -19,8 +21,8 @@ abstract class BoardPage extends Page implements HasActions, HasBoard, HasForms
     use BaseBoard;
 
     // Fix for Filament v4 navigation property types
-    protected static string|\UnitEnum|null $navigationGroup = null;
-    protected static string|\BackedEnum|null $navigationIcon = null;
+    protected static string|UnitEnum|null $navigationGroup = null;
+    protected static string|BackedEnum|null $navigationIcon = null;
     protected static ?string $navigationLabel = null;
     protected static ?int $navigationSort = null;
 

--- a/src/BoardPage.php
+++ b/src/BoardPage.php
@@ -18,5 +18,11 @@ abstract class BoardPage extends Page implements HasActions, HasBoard, HasForms
 {
     use BaseBoard;
 
+    // Fix for Filament v4 navigation property types
+    protected static string|\UnitEnum|null $navigationGroup = null;
+    protected static string|\BackedEnum|null $navigationIcon = null;
+    protected static ?string $navigationLabel = null;
+    protected static ?int $navigationSort = null;
+
     protected string $view = 'flowforge::filament.pages.board-page';
 }


### PR DESCRIPTION
- Add union types for navigationGroup and navigationIcon
- Maintains backward compatibility
- Fixes PHP Fatal Error when setting navigation properties
- Tested with Laravel 11 + Filament v4