### PR TITLE
protected static ?string => protected static string|null|\BackedEnum

### DIFF
--- a/stubs/kanban-board-page.stub
+++ b/stubs/kanban-board-page.stub
@@ -10,7 +10,7 @@ use Relaticle\Flowforge\Column;
 
 class {{ class }} extends BoardPage
 {
-    protected static ?string $navigationIcon = 'heroicon-o-view-columns';
+    protected static string|null|\BackedEnum $navigationIcon = 'heroicon-o-view-columns';
     protected static ?string $navigationLabel = '{{ navigationLabel }}';
     protected static ?string $title = '{{ title }}';
 


### PR DESCRIPTION
The data type of the $navigationIcon property has changed because Filament v4 uses string|null|\BackedEnum