### PR TITLE
Add Spanish translation for Flowforge

### DIFF
--- a/resources/lang/es/flowforge.php
+++ b/resources/lang/es/flowforge.php
@@ -1,0 +1,11 @@
+<?php
+
+return [
+    'loading_more_cards' => 'Cargando más tarjetas...',
+    'no_cards_in_column' => 'No hay :cardLabel en esta columna',
+    'cards_count' => '{0} :cards|{1} :card|[2,*] :cards',
+    'card_label' => 'Registro',
+    'plural_card_label' => 'Registros',
+    'cards_pagination' => ':current de :total :cards',
+    'all_cards_loaded' => 'Se cargaron todos los :total :cards',
+];


### PR DESCRIPTION
### Summary
This pull request adds Spanish (es) language support for Flowforge.

### Changes
- Added a new localization file: `resources/lang/es/flowforge.php`
- Translated all existing strings from English to Spanish, maintaining variable placeholders like `:cardLabel`, `:cards`, and `:total`.

