### PR TITLE
Add icon support to Flowforge Board columns

### DIFF
--- a/resources/views/livewire/column.blade.php
+++ b/resources/views/livewire/column.blade.php
@@ -16,6 +16,9 @@
     <!-- Column Header -->
     <div class="flowforge-column-header flex items-center justify-between py-3 px-4 border-b border-gray-200 dark:border-gray-700">
         <div class="flex items-center">
+            @if ($column['icon'] ?? null)
+                <x-filament::icon :icon="$column['icon']" class="h-4 w-4 text-gray-500 dark:text-gray-400 me-2" />
+            @endif
             <h3 class="text-sm font-medium text-gray-700 dark:text-gray-200">
                 {{ $column['label'] }}
             </h3>

--- a/src/Board.php
+++ b/src/Board.php
@@ -71,6 +71,7 @@ class Board extends ViewComponent
                 'id' => $columnId,
                 'label' => $column->getLabel(),
                 'color' => $column->getColor(),
+                'icon' => $column->getIcon(),
                 'items' => $formattedRecords,
                 'total' => $this->getBoardRecordCount($columnId),
             ];


### PR DESCRIPTION
## Changes
- Added `icon` field to column data array in `Board::getViewData()`
- Updated column header template to render icons when provided
- Icons are rendered using Filament's icon component with appropriate styling

## Why
The `Column` class already supports icons via the `HasIcon` trait, but icons weren't being included in the view data or rendered in the template. This enables users to display icons in column headers.