### PR TITLE
refactor: add isMounting parameter to resolveActions method to match filament4.4 structure

### DIFF
--- a/src/BoardResourcePage.php
+++ b/src/BoardResourcePage.php
@@ -41,7 +41,7 @@ abstract class BoardResourcePage extends Page implements HasActions, HasBoard, H
      *
      * @throws \Filament\Actions\Exceptions\ActionNotResolvableException
      */
-    protected function resolveActions(array $actions): array
+    protected function resolveActions(array $actions, bool $isMounting = true): array
     {
         $resolvedActions = [];
 


### PR DESCRIPTION
Filament4.4 introduces a new [$isMounting parameter in the resolveActions method](https://github.com/filamentphp/filament/commit/e44b7d831d2e8377378f89fbf8d3a26938b2c5ac#diff-51df1d629bd1d44d325a24cb720603bc32cd0d97acfd82d7acf7f445d9b5b72eR484), which broke the code. I noticed this today, when I tried to run _composer update_ and this error was displayed:
<img width="1402" height="700" alt="Screenshot 2026-01-04 at 17 11 29" src="https://github.com/user-attachments/assets/5fb2b016-81cf-494e-859f-2c3fa648d3c6" />