### PR TITLE
fix: import DB facade for database operations in HasBoardRecords

### DIFF
--- a/src/Concerns/HasBoardRecords.php
+++ b/src/Concerns/HasBoardRecords.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Relaticle\Flowforge\Concerns;
 
-use DB;
 use Exception;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\DB;
 
 /**
  * Enterprise-grade record management for Board with cursor-based pagination.


### PR DESCRIPTION
Error when using data query in the getBatchedBoardRecordCounts function which is importing the DB face instead of Illuminate\Support\Facades\DB.