### PR TITLE
fix: batch board records fetch to eliminate per-column N+1 queries

### DIFF
--- a/src/Board.php
+++ b/src/Board.php
@@ -58,16 +58,15 @@ class Board extends ViewComponent
      */
     public function getViewData(): array
     {
-        // Batch all column counts in a single query
         $allCounts = $this->getBatchedBoardRecordCounts();
+        $batchedRecords = $this->getBatchedBoardRecords();
 
-        // Build columns data using new concerns
         $columns = [];
+
         foreach ($this->getColumns() as $column) {
             $columnId = $column->getName();
 
-            // Get formatted records
-            $records = $this->getBoardRecords($columnId);
+            $records = $batchedRecords[$columnId] ?? new \Illuminate\Database\Eloquent\Collection;
             $formattedRecords = $records->map(fn ($record) => $this->formatBoardRecord($record))->toArray();
 
             $columns[$columnId] = [

--- a/src/Concerns/HasBoardRecords.php
+++ b/src/Concerns/HasBoardRecords.php
@@ -149,6 +149,55 @@ trait HasBoardRecords
     }
 
     /**
+     * Get records for ALL columns in a single query, partitioned in PHP.
+     *
+     * @return array<string, Collection>
+     */
+    public function getBatchedBoardRecords(): array
+    {
+        $query = $this->getQuery();
+
+        if (! $query) {
+            return [];
+        }
+
+        $statusField = $this->getColumnIdentifierAttribute();
+        $positionField = $this->getPositionIdentifierAttribute();
+        $limit = $this->getCardsPerColumn();
+        $livewire = $this->getLivewire();
+
+        $baseQuery = clone $query;
+
+        if ($livewire->getTable()->isFilterable() || $livewire->hasTableSearch()) {
+            $baseQuery = clone $livewire->getFilteredTableQuery();
+        }
+
+        $keyName = $baseQuery->getModel()->getKeyName();
+        $columnIds = collect($this->getColumns())->map(fn ($col) => $col->getName())->all();
+
+        $allRecords = (clone $baseQuery)
+            ->whereIn($statusField, $columnIds)
+            ->orderBy($positionField, 'asc')
+            ->orderBy($keyName, 'asc')
+            ->get();
+
+        $partitioned = [];
+
+        foreach ($columnIds as $columnId) {
+            $columnLimit = property_exists($livewire, 'columnCardLimits')
+                ? ($livewire->columnCardLimits[$columnId] ?? $limit)
+                : $limit;
+
+            $partitioned[$columnId] = $allRecords
+                ->filter(fn ($record) => (string) data_get($record, $statusField) === (string) $columnId)
+                ->take($columnLimit)
+                ->values();
+        }
+
+        return $partitioned;
+    }
+
+    /**
      * Format a record for display with Infolist entries.
      */
     public function formatBoardRecord(Model $record): array


### PR DESCRIPTION
## Summary

- Replace per-column `getBoardRecords()` calls in `Board::getViewData()` with a single `getBatchedBoardRecords()` query
- Fetches all column records in one query, then partitions in PHP
- Eliminates N+1 queries proportional to the number of board columns

## Test plan

- [x] Verified locally with OpportunitiesBoard and TasksBoard
- [x] Board renders correctly with batched records