### PR TITLE
Add Hebrew language

### DIFF
--- a/resources/lang/he/flowforge.php
+++ b/resources/lang/he/flowforge.php
@@ -1,0 +1,11 @@
+<?php
+
+return [
+    'loading_more_cards' => 'טוען כרטיסים נוספים...',
+    'no_cards_in_column' => 'אין :cardLabel בעמודה זו',
+    'cards_count' => '{0} :cards|{1} :card|[2,*] :cards',
+    'card_label' => 'רשומה',
+    'plural_card_label' => 'רשומות',
+    'cards_pagination' => ':current מתוך :total :cards',
+    'all_cards_loaded' => 'כל :total ה-:cards נטענו',
+];


### PR DESCRIPTION
Hi! First of all — thanks for this awesome and well-maintained Filament plugin 🙌

I noticed the Hebrew (he) translation exists on the 2.x branch, but it doesn’t seem to be included in the 4.x docs/release (maybe it was missed during the version bump).

Thanks again!
