### PR TITLE
[4.x] Cast id to string to avoid snowflake ids being treated as floats

### DIFF
--- a/resources/views/livewire/card.blade.php
+++ b/resources/views/livewire/card.blade.php
@@ -16,8 +16,8 @@
         'cursor-grab hover:cursor-grabbing' => $hasPositionIdentifier,
         'cursor-default' => !$hasActions && !$hasCardAction && !$hasPositionIdentifier,
     ])
-    x-sortable-item="{{ $record['id'] }}"
-    data-card-id="{{ $record['id'] }}"
+    x-sortable-item="{{ (string) $record['id'] }}"
+    data-card-id="{{ (string) $record['id'] }}"
     @if($hasPositionIdentifier)
         x-sortable-handle
     @endif
@@ -27,7 +27,7 @@
         <div class="flex items-start justify-between mb-2">
             <h4 class="text-sm font-semibold text-gray-900 dark:text-white p-3"
                 @if($hasCardAction && $cardAction)
-                    wire:click="mountAction('{{ $cardAction }}', [], @js(['recordKey' => $record['id']]))"
+                    wire:click="mountAction('{{ $cardAction }}', [], @js(['recordKey' => (string) $record['id']]))"
                 style="cursor: pointer;"
                 @endif
             >
@@ -43,7 +43,7 @@
 
         <div class="px-3 pb-3"
              @if($hasCardAction && $cardAction)
-                 wire:click="mountAction('{{ $cardAction }}', [], @js(['recordKey' => $record['id']]))"
+                 wire:click="mountAction('{{ $cardAction }}', [], @js(['recordKey' => (string) $record['id']]))"
              style="cursor: pointer;"
             @endif
         >


### PR DESCRIPTION
Using snowflakes instead of standard ids causes ids to be treated as floats changing the id.

for example task.id is 420533451316027392 when using
```php
@js(['recordKey' => $record['id']]))"
```
the snowflake is being treated by js as a float and losing precision so casting to a string resolves this.

```php
@js(['recordKey' => (string) $record['id']]))"
```

Closes #88 