### PR TITLE
ci: add auto-release workflow and normalize CI naming

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,4 +1,4 @@
-name: "Dependabot Auto-Merge"
+name: Auto-Merge
 
 on: pull_request_target
 

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,4 +1,4 @@
-name: "Update Changelog"
+name: Changelog
 
 on:
   release:
@@ -15,10 +15,13 @@ jobs:
       - name: Determine target branch
         id: branch
         run: |
-          # Extract major version from tag (v4.0.1 -> 4.x)
           TAG="${{ github.event.release.tag_name }}"
-          MAJOR=$(echo "$TAG" | sed -E 's/^v([0-9]+)\..*/\1/')
-          echo "name=${MAJOR}.x" >> $GITHUB_OUTPUT
+          MAJOR=$(echo "$TAG" | sed -E 's/^v?([0-9]+)\..*/\1/')
+          BRANCH="${MAJOR}.x"
+          if ! git ls-remote --exit-code --heads "https://github.com/${{ github.repository }}" "$BRANCH" > /dev/null 2>&1; then
+            BRANCH="${{ github.event.repository.default_branch }}"
+          fi
+          echo "name=${BRANCH}" >> $GITHUB_OUTPUT
 
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/pint.yml
+++ b/.github/workflows/pint.yml
@@ -1,4 +1,4 @@
-name: "Fix PHP Code Styling"
+name: Pint
 
 on:
   push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,51 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: write
+
+jobs:
+  tests:
+    uses: ./.github/workflows/tests.yml
+    secrets: inherit
+
+  release:
+    needs: tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Determine if pre-release
+        id: prerelease
+        run: |
+          TAG="${{ github.ref_name }}"
+          if [[ "$TAG" == *"-"* ]]; then
+            echo "flag=--prerelease" >> $GITHUB_OUTPUT
+          else
+            echo "flag=" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create GitHub Release
+        run: gh release create "${{ github.ref_name }}" --generate-notes ${{ steps.prerelease.outputs.flag }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  cleanup:
+    needs: tests
+    if: failure()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Delete tag on test failure
+        run: git push --delete origin "${{ github.ref_name }}"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,10 +1,11 @@
-name: run-tests
+name: Tests
 
 on:
   push:
     branches: [3.x]
   pull_request:
     branches: [3.x]
+  workflow_call:
 
 jobs:
   test:


### PR DESCRIPTION
## Summary

- Rename workflow files to normalized names (tests.yml, changelog.yml, pint.yml, auto-merge.yml)
- Add new release.yml auto-release workflow
- Update branch references in tests.yml from 4.x to 3.x

Cherry-picked from the chore/auto-release-ci-normalization branch on 4.x.