### PR TITLE
feat: add headerToolbar() for inline filter/search in page header

### DIFF
--- a/docs/content/2.essentials/2.customization.md
+++ b/docs/content/2.essentials/2.customization.md
@@ -138,6 +138,24 @@ public function board(Board $board): Board
 }
 ```
 
+## Header Toolbar
+
+By default, filters and search render in a separate toolbar above the board. Enable `headerToolbar()` to move them inline with the page title for a more compact layout:
+
+```php
+public function board(Board $board): Board
+{
+    return $board
+        ->searchable(['title', 'description'])
+        ->filters([
+            SelectFilter::make('priority')->options([...]),
+        ])
+        ->headerToolbar();
+}
+```
+
+The header toolbar supports `Dropdown` and `Modal` filter layouts. For other layouts (AboveContent, BeforeContent, etc.), leave `headerToolbar` disabled (the default) and the full filter view will be used instead.
+
 ## Search and Filtering
 
 Enable powerful search and filtering capabilities:

--- a/docs/content/2.essentials/4.api-reference.md
+++ b/docs/content/2.essentials/4.api-reference.md
@@ -24,6 +24,7 @@ navigation:
 | `filtersFormWidth(Width)` | Filter panel width | |
 | `filtersFormColumns(int)` | Columns in filter form | |
 | `filtersLayout(FiltersLayout)` | Filter display layout (Dropdown, AboveContent, etc.) | |
+| `headerToolbar(bool)` | Render filters/search inline with page title | |
 
 ## Board Methods
 
@@ -84,6 +85,7 @@ use Filament\Support\Enums\Width;
 ->filtersLayout(FiltersLayout::AboveContent)      // Display filters above board
 ->filtersFormWidth(Width::Large)                  // Filter panel width
 ->filtersFormColumns(3)                           // Columns in filter form
+->headerToolbar()                                 // Inline filters/search in page header
 ```
 
 ## Column Configuration

--- a/resources/views/filament/pages/board-header.blade.php
+++ b/resources/views/filament/pages/board-header.blade.php
@@ -1,10 +1,12 @@
 @php
     use Filament\Support\Enums\IconSize;
     use Filament\Support\Enums\Width;
+    use Filament\Support\Facades\FilamentView;
     use Filament\Support\Icons\Heroicon;
     use Filament\Tables\Enums\FiltersLayout;
     use Filament\Tables\Filters\Indicator;
     use Filament\Tables\View\TablesIconAlias;
+    use Filament\Tables\View\TablesRenderHook;
 
     use function Filament\Support\generate_icon_html;
 
@@ -27,6 +29,7 @@
     }
 
     $hasFiltersDialog = $isFilterable && in_array($filtersLayout, [FiltersLayout::Dropdown, FiltersLayout::Modal]);
+    $isModalLayout = ($filtersLayout === FiltersLayout::Modal) || ($hasFiltersDialog && $filtersTriggerAction->isModalSlideOver());
 @endphp
 
 <div class="fi-page-header-main-ctn !gap-y-2 !pt-4 !pb-0">
@@ -50,31 +53,80 @@
         </div>
 
         <div class="flex items-center gap-x-6 shrink-0">
-            {{-- Wrap in fi-ta-ctn context so Filament's scoped table CSS applies to filters --}}
             @if ($isFilterable && $hasFiltersDialog)
-                <div class="fi-ta-ctn fi-ta-ctn-with-header" style="display: contents;">
-                    <div class="fi-ta-header-toolbar" style="display: contents;">
-                        <x-filament::dropdown
-                            :max-height="$filtersFormMaxHeight"
-                            placement="bottom-end"
-                            shift
-                            :flip="false"
-                            :width="$filtersFormWidth ?? Width::ExtraSmall"
-                            :wire:key="$this->getId() . '.board.filters'"
-                            class="fi-ta-filters-dropdown"
-                        >
-                            <x-slot name="trigger">
-                                {{ $filtersTriggerAction->badge($activeFiltersCount) }}
-                            </x-slot>
+                @if ($isModalLayout)
+                    @php
+                        $filtersTriggerActionModalAlignment = $filtersTriggerAction->getModalAlignment();
+                        $filtersTriggerActionIsModalAutofocused = $filtersTriggerAction->isModalAutofocused();
+                        $filtersTriggerActionHasModalCloseButton = $filtersTriggerAction->hasModalCloseButton();
+                        $filtersTriggerActionIsModalClosedByClickingAway = $filtersTriggerAction->isModalClosedByClickingAway();
+                        $filtersTriggerActionIsModalClosedByEscaping = $filtersTriggerAction->isModalClosedByEscaping();
+                        $filtersTriggerActionModalDescription = $filtersTriggerAction->getModalDescription();
+                        $filtersTriggerActionVisibleModalFooterActions = $filtersTriggerAction->getVisibleModalFooterActions();
+                        $filtersTriggerActionModalFooterActionsAlignment = $filtersTriggerAction->getModalFooterActionsAlignment();
+                        $filtersTriggerActionModalHeading = $filtersTriggerAction->getCustomModalHeading() ?? __('filament-tables::table.filters.heading');
+                        $filtersTriggerActionModalIcon = $filtersTriggerAction->getModalIcon();
+                        $filtersTriggerActionModalIconColor = $filtersTriggerAction->getModalIconColor();
+                        $filtersTriggerActionIsModalSlideOver = $filtersTriggerAction->isModalSlideOver();
+                        $filtersTriggerActionIsModalFooterSticky = $filtersTriggerAction->isModalFooterSticky();
+                        $filtersTriggerActionIsModalHeaderSticky = $filtersTriggerAction->isModalHeaderSticky();
+                    @endphp
 
-                            <x-filament-tables::filters
-                                :apply-action="$filtersApplyAction"
-                                :form="$filtersForm"
-                                :reset-action-position="$filtersResetActionPosition"
-                            />
-                        </x-filament::dropdown>
+                    <x-filament::modal
+                        :alignment="$filtersTriggerActionModalAlignment"
+                        :autofocus="$filtersTriggerActionIsModalAutofocused"
+                        :close-button="$filtersTriggerActionHasModalCloseButton"
+                        :close-by-clicking-away="$filtersTriggerActionIsModalClosedByClickingAway"
+                        :close-by-escaping="$filtersTriggerActionIsModalClosedByEscaping"
+                        :description="$filtersTriggerActionModalDescription"
+                        :footer-actions="$filtersTriggerActionVisibleModalFooterActions"
+                        :footer-actions-alignment="$filtersTriggerActionModalFooterActionsAlignment"
+                        :heading="$filtersTriggerActionModalHeading"
+                        :icon="$filtersTriggerActionModalIcon"
+                        :icon-color="$filtersTriggerActionModalIconColor"
+                        :slide-over="$filtersTriggerActionIsModalSlideOver"
+                        :sticky-footer="$filtersTriggerActionIsModalFooterSticky"
+                        :sticky-header="$filtersTriggerActionIsModalHeaderSticky"
+                        :width="$filtersFormWidth"
+                        :wire:key="$this->getId() . '.board.filters'"
+                        class="fi-ta-filters-modal"
+                    >
+                        <x-slot name="trigger">
+                            {{ $filtersTriggerAction->badge($activeFiltersCount) }}
+                        </x-slot>
+
+                        {{ $filtersTriggerAction->getModalContent() }}
+
+                        {{ $filtersForm }}
+
+                        {{ $filtersTriggerAction->getModalContentFooter() }}
+                    </x-filament::modal>
+                @else
+                    {{-- Wrap in fi-ta-ctn context so Filament's scoped table CSS applies to filters --}}
+                    <div class="fi-ta-ctn fi-ta-ctn-with-header" style="display: contents;">
+                        <div class="fi-ta-header-toolbar" style="display: contents;">
+                            <x-filament::dropdown
+                                :max-height="$filtersFormMaxHeight"
+                                placement="bottom-end"
+                                shift
+                                :flip="false"
+                                :width="$filtersFormWidth ?? Width::ExtraSmall"
+                                :wire:key="$this->getId() . '.board.filters'"
+                                class="fi-ta-filters-dropdown"
+                            >
+                                <x-slot name="trigger">
+                                    {{ $filtersTriggerAction->badge($activeFiltersCount) }}
+                                </x-slot>
+
+                                <x-filament-tables::filters
+                                    :apply-action="$filtersApplyAction"
+                                    :form="$filtersForm"
+                                    :reset-action-position="$filtersResetActionPosition"
+                                />
+                            </x-filament::dropdown>
+                        </div>
                     </div>
-                </div>
+                @endif
             @endif
 
             @if ($isSearchable)
@@ -89,40 +141,44 @@
 
     {{-- Active filter indicators --}}
     @if ($filterIndicators)
-        <div class="fi-ta-filter-indicators flex items-center gap-x-2 mt-3">
-            <div class="flex flex-wrap items-center gap-1">
-                @foreach ($filterIndicators as $indicator)
-                    <x-filament::badge :color="$indicator->getColor()">
-                        {{ $indicator->getLabel() }}
+        @if (filled($filterIndicatorsView = FilamentView::renderHook(TablesRenderHook::FILTER_INDICATORS, scopes: static::class, data: ['filterIndicators' => $filterIndicators])))
+            {{ $filterIndicatorsView }}
+        @else
+            <div class="fi-ta-filter-indicators flex items-center gap-x-2">
+                <div class="flex flex-wrap items-center gap-1">
+                    @foreach ($filterIndicators as $indicator)
+                        <x-filament::badge :color="$indicator->getColor()">
+                            {{ $indicator->getLabel() }}
 
-                        @if ($indicator->isRemovable())
-                            <x-slot
-                                name="deleteButton"
-                                :label="__('filament-tables::table.filters.actions.remove.label')"
-                                :wire:click="$indicator->getRemoveLivewireClickHandler()"
-                                wire:loading.attr="disabled"
-                                wire:target="removeTableFilter"
-                            ></x-slot>
-                        @endif
-                    </x-filament::badge>
-                @endforeach
+                            @if ($indicator->isRemovable())
+                                <x-slot
+                                    name="deleteButton"
+                                    :label="__('filament-tables::table.filters.actions.remove.label')"
+                                    :wire:click="$indicator->getRemoveLivewireClickHandler()"
+                                    wire:loading.attr="disabled"
+                                    wire:target="removeTableFilter"
+                                ></x-slot>
+                            @endif
+                        </x-filament::badge>
+                    @endforeach
+                </div>
+
+                @if (collect($filterIndicators)->contains(fn (Indicator $indicator): bool => $indicator->isRemovable()))
+                    <button
+                        type="button"
+                        x-tooltip="{
+                            content: @js(__('filament-tables::table.filters.actions.remove_all.tooltip')),
+                            theme: $store.theme,
+                        }"
+                        wire:click="removeTableFilters"
+                        wire:loading.attr="disabled"
+                        wire:target="removeTableFilters,removeTableFilter"
+                        class="fi-icon-btn fi-size-sm"
+                    >
+                        {{ generate_icon_html(Heroicon::XMark, alias: TablesIconAlias::FILTERS_REMOVE_ALL_BUTTON, size: IconSize::Small) }}
+                    </button>
+                @endif
             </div>
-
-            @if (collect($filterIndicators)->contains(fn (Indicator $indicator): bool => $indicator->isRemovable()))
-                <button
-                    type="button"
-                    x-tooltip="{
-                        content: @js(__('filament-tables::table.filters.actions.remove_all.tooltip')),
-                        theme: $store.theme,
-                    }"
-                    wire:click="removeTableFilters"
-                    wire:loading.attr="disabled"
-                    wire:target="removeTableFilters,removeTableFilter"
-                    class="fi-icon-btn fi-size-sm"
-                >
-                    {{ generate_icon_html(Heroicon::XMark, alias: TablesIconAlias::FILTERS_REMOVE_ALL_BUTTON, size: IconSize::Small) }}
-                </button>
-            @endif
-        </div>
+        @endif
     @endif
 </div>

--- a/resources/views/filament/pages/board-header.blade.php
+++ b/resources/views/filament/pages/board-header.blade.php
@@ -29,20 +29,7 @@
     $hasFiltersDialog = $isFilterable && in_array($filtersLayout, [FiltersLayout::Dropdown, FiltersLayout::Modal]);
 @endphp
 
-<style>
-    .fi-board-header-toolbar .fi-dropdown-panel {
-        background: white;
-        box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -4px rgba(0, 0, 0, 0.1);
-        border: 1px solid rgba(0, 0, 0, 0.05);
-        border-radius: 12px;
-    }
-    .dark .fi-board-header-toolbar .fi-dropdown-panel {
-        background: rgb(17, 24, 39);
-        border-color: rgba(255, 255, 255, 0.1);
-    }
-</style>
-
-<div class="fi-page-header-main-ctn fi-board-header-toolbar">
+<div class="fi-page-header-main-ctn !gap-y-2 !pt-4 !pb-0">
     {{-- Breadcrumbs --}}
     @if (filled($breadcrumbs))
         <x-filament::breadcrumbs :breadcrumbs="$breadcrumbs" class="mb-2" />
@@ -62,27 +49,32 @@
             @endif
         </div>
 
-        <div class="flex items-center gap-x-3 shrink-0">
+        <div class="flex items-center gap-x-6 shrink-0">
+            {{-- Wrap in fi-ta-ctn context so Filament's scoped table CSS applies to filters --}}
             @if ($isFilterable && $hasFiltersDialog)
-                <x-filament::dropdown
-                    :max-height="$filtersFormMaxHeight"
-                    placement="bottom-end"
-                    shift
-                    :flip="false"
-                    :width="$filtersFormWidth ?? Width::ExtraSmall"
-                    :wire:key="$this->getId() . '.board.filters'"
-                    class="fi-ta-filters-dropdown"
-                >
-                    <x-slot name="trigger">
-                        {{ $filtersTriggerAction->badge($activeFiltersCount) }}
-                    </x-slot>
+                <div class="fi-ta-ctn fi-ta-ctn-with-header" style="display: contents;">
+                    <div class="fi-ta-header-toolbar" style="display: contents;">
+                        <x-filament::dropdown
+                            :max-height="$filtersFormMaxHeight"
+                            placement="bottom-end"
+                            shift
+                            :flip="false"
+                            :width="$filtersFormWidth ?? Width::ExtraSmall"
+                            :wire:key="$this->getId() . '.board.filters'"
+                            class="fi-ta-filters-dropdown"
+                        >
+                            <x-slot name="trigger">
+                                {{ $filtersTriggerAction->badge($activeFiltersCount) }}
+                            </x-slot>
 
-                    <x-filament-tables::filters
-                        :apply-action="$filtersApplyAction"
-                        :form="$filtersForm"
-                        :reset-action-position="$filtersResetActionPosition"
-                    />
-                </x-filament::dropdown>
+                            <x-filament-tables::filters
+                                :apply-action="$filtersApplyAction"
+                                :form="$filtersForm"
+                                :reset-action-position="$filtersResetActionPosition"
+                            />
+                        </x-filament::dropdown>
+                    </div>
+                </div>
             @endif
 
             @if ($isSearchable)

--- a/resources/views/filament/pages/board-header.blade.php
+++ b/resources/views/filament/pages/board-header.blade.php
@@ -29,7 +29,7 @@
     $hasFiltersDialog = $isFilterable && in_array($filtersLayout, [FiltersLayout::Dropdown, FiltersLayout::Modal]);
 @endphp
 
-<div class="fi-header fi-page-header-main-ctn">
+<div class="fi-page-header-main-ctn">
     {{-- Breadcrumbs --}}
     @if (filled($breadcrumbs))
         <x-filament::breadcrumbs :breadcrumbs="$breadcrumbs" class="mb-2" />

--- a/resources/views/filament/pages/board-header.blade.php
+++ b/resources/views/filament/pages/board-header.blade.php
@@ -49,7 +49,7 @@
             @endif
         </div>
 
-        <div class="flex items-center gap-x-3 shrink-0">
+        <div class="fi-ta-ctn flex items-center gap-x-3 shrink-0 !overflow-visible !shadow-none !ring-0 !bg-transparent">
             @if ($isFilterable && $hasFiltersDialog)
                 <x-filament::dropdown
                     :max-height="$filtersFormMaxHeight"
@@ -58,6 +58,7 @@
                     :flip="false"
                     :width="$filtersFormWidth ?? Width::ExtraSmall"
                     :wire:key="$this->getId() . '.board.filters'"
+                    class="fi-ta-filters-dropdown"
                 >
                     <x-slot name="trigger">
                         {{ $filtersTriggerAction->badge($activeFiltersCount) }}

--- a/resources/views/filament/pages/board-header.blade.php
+++ b/resources/views/filament/pages/board-header.blade.php
@@ -29,7 +29,20 @@
     $hasFiltersDialog = $isFilterable && in_array($filtersLayout, [FiltersLayout::Dropdown, FiltersLayout::Modal]);
 @endphp
 
-<div class="fi-page-header-main-ctn">
+<style>
+    .fi-board-header-toolbar .fi-dropdown-panel {
+        background: white;
+        box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -4px rgba(0, 0, 0, 0.1);
+        border: 1px solid rgba(0, 0, 0, 0.05);
+        border-radius: 12px;
+    }
+    .dark .fi-board-header-toolbar .fi-dropdown-panel {
+        background: rgb(17, 24, 39);
+        border-color: rgba(255, 255, 255, 0.1);
+    }
+</style>
+
+<div class="fi-page-header-main-ctn fi-board-header-toolbar">
     {{-- Breadcrumbs --}}
     @if (filled($breadcrumbs))
         <x-filament::breadcrumbs :breadcrumbs="$breadcrumbs" class="mb-2" />
@@ -49,7 +62,7 @@
             @endif
         </div>
 
-        <div class="fi-ta-ctn flex items-center gap-x-3 shrink-0 !overflow-visible !shadow-none !ring-0 !bg-transparent">
+        <div class="flex items-center gap-x-3 shrink-0">
             @if ($isFilterable && $hasFiltersDialog)
                 <x-filament::dropdown
                     :max-height="$filtersFormMaxHeight"

--- a/resources/views/filament/pages/board-header.blade.php
+++ b/resources/views/filament/pages/board-header.blade.php
@@ -36,8 +36,8 @@
     @endif
 
     {{-- Title row: heading + filter + search --}}
-    <div class="flex items-center justify-between gap-4">
-        <div class="min-w-0">
+    <div class="flex items-center gap-4">
+        <div class="flex-1 min-w-0">
             <h1 class="fi-header-heading text-2xl font-bold tracking-tight text-gray-950 dark:text-white sm:text-3xl">
                 {{ $heading }}
             </h1>
@@ -83,25 +83,23 @@
 
     {{-- Active filter indicators --}}
     @if ($filterIndicators)
-        <div class="fi-ta-filter-indicators mt-3">
-            <div>
-                <div class="fi-ta-filter-indicators-badges-ctn">
-                    @foreach ($filterIndicators as $indicator)
-                        <x-filament::badge :color="$indicator->getColor()">
-                            {{ $indicator->getLabel() }}
+        <div class="fi-ta-filter-indicators flex items-center gap-x-2 mt-3">
+            <div class="flex flex-wrap items-center gap-1">
+                @foreach ($filterIndicators as $indicator)
+                    <x-filament::badge :color="$indicator->getColor()">
+                        {{ $indicator->getLabel() }}
 
-                            @if ($indicator->isRemovable())
-                                <x-slot
-                                    name="deleteButton"
-                                    :label="__('filament-tables::table.filters.actions.remove.label')"
-                                    :wire:click="$indicator->getRemoveLivewireClickHandler()"
-                                    wire:loading.attr="disabled"
-                                    wire:target="removeTableFilter"
-                                ></x-slot>
-                            @endif
-                        </x-filament::badge>
-                    @endforeach
-                </div>
+                        @if ($indicator->isRemovable())
+                            <x-slot
+                                name="deleteButton"
+                                :label="__('filament-tables::table.filters.actions.remove.label')"
+                                :wire:click="$indicator->getRemoveLivewireClickHandler()"
+                                wire:loading.attr="disabled"
+                                wire:target="removeTableFilter"
+                            ></x-slot>
+                        @endif
+                    </x-filament::badge>
+                @endforeach
             </div>
 
             @if (collect($filterIndicators)->contains(fn (Indicator $indicator): bool => $indicator->isRemovable()))

--- a/resources/views/filament/pages/board-header.blade.php
+++ b/resources/views/filament/pages/board-header.blade.php
@@ -1,0 +1,124 @@
+@php
+    use Filament\Support\Enums\IconSize;
+    use Filament\Support\Enums\Width;
+    use Filament\Support\Icons\Heroicon;
+    use Filament\Tables\Enums\FiltersLayout;
+    use Filament\Tables\Filters\Indicator;
+    use Filament\Tables\View\TablesIconAlias;
+
+    use function Filament\Support\generate_icon_html;
+
+    $table = $this->getTable();
+    $isFilterable = $table->isFilterable();
+    $isSearchable = $table->isSearchable();
+    $filterIndicators = $table->getFilterIndicators();
+
+    $filtersLayout = $table->getFiltersLayout();
+    $filtersTriggerAction = $table->getFiltersTriggerAction();
+    $filtersApplyAction = $table->getFiltersApplyAction();
+    $filtersForm = $this->getTableFiltersForm();
+    $filtersFormWidth = $table->getFiltersFormWidth();
+    $filtersFormMaxHeight = $table->getFiltersFormMaxHeight();
+    $filtersResetActionPosition = $table->getFiltersResetActionPosition();
+    $activeFiltersCount = $table->getActiveFiltersCount();
+
+    if (is_string($filtersFormWidth)) {
+        $filtersFormWidth = Width::tryFrom($filtersFormWidth) ?? $filtersFormWidth;
+    }
+
+    $hasFiltersDialog = $isFilterable && in_array($filtersLayout, [FiltersLayout::Dropdown, FiltersLayout::Modal]);
+@endphp
+
+<div class="fi-header fi-page-header-main-ctn">
+    {{-- Breadcrumbs --}}
+    @if (filled($breadcrumbs))
+        <x-filament::breadcrumbs :breadcrumbs="$breadcrumbs" class="mb-2" />
+    @endif
+
+    {{-- Title row: heading + filter + search --}}
+    <div class="flex items-center justify-between gap-4">
+        <div class="min-w-0">
+            <h1 class="fi-header-heading text-2xl font-bold tracking-tight text-gray-950 dark:text-white sm:text-3xl">
+                {{ $heading }}
+            </h1>
+
+            @if (filled($subheading))
+                <p class="fi-header-subheading mt-1 max-w-2xl text-sm text-gray-600 dark:text-gray-400">
+                    {{ $subheading }}
+                </p>
+            @endif
+        </div>
+
+        <div class="flex items-center gap-x-3 shrink-0">
+            @if ($isFilterable && $hasFiltersDialog)
+                <x-filament::dropdown
+                    :max-height="$filtersFormMaxHeight"
+                    placement="bottom-end"
+                    shift
+                    :flip="false"
+                    :width="$filtersFormWidth ?? Width::ExtraSmall"
+                    :wire:key="$this->getId() . '.board.filters'"
+                >
+                    <x-slot name="trigger">
+                        {{ $filtersTriggerAction->badge($activeFiltersCount) }}
+                    </x-slot>
+
+                    <x-filament-tables::filters
+                        :apply-action="$filtersApplyAction"
+                        :form="$filtersForm"
+                        :reset-action-position="$filtersResetActionPosition"
+                    />
+                </x-filament::dropdown>
+            @endif
+
+            @if ($isSearchable)
+                <x-filament-tables::search-field
+                    :debounce="$table->getSearchDebounce()"
+                    :on-blur="$table->isSearchOnBlur()"
+                    :placeholder="$table->getSearchPlaceholder()"
+                />
+            @endif
+        </div>
+    </div>
+
+    {{-- Active filter indicators --}}
+    @if ($filterIndicators)
+        <div class="fi-ta-filter-indicators mt-3">
+            <div>
+                <div class="fi-ta-filter-indicators-badges-ctn">
+                    @foreach ($filterIndicators as $indicator)
+                        <x-filament::badge :color="$indicator->getColor()">
+                            {{ $indicator->getLabel() }}
+
+                            @if ($indicator->isRemovable())
+                                <x-slot
+                                    name="deleteButton"
+                                    :label="__('filament-tables::table.filters.actions.remove.label')"
+                                    :wire:click="$indicator->getRemoveLivewireClickHandler()"
+                                    wire:loading.attr="disabled"
+                                    wire:target="removeTableFilter"
+                                ></x-slot>
+                            @endif
+                        </x-filament::badge>
+                    @endforeach
+                </div>
+            </div>
+
+            @if (collect($filterIndicators)->contains(fn (Indicator $indicator): bool => $indicator->isRemovable()))
+                <button
+                    type="button"
+                    x-tooltip="{
+                        content: @js(__('filament-tables::table.filters.actions.remove_all.tooltip')),
+                        theme: $store.theme,
+                    }"
+                    wire:click="removeTableFilters"
+                    wire:loading.attr="disabled"
+                    wire:target="removeTableFilters,removeTableFilter"
+                    class="fi-icon-btn fi-size-sm"
+                >
+                    {{ generate_icon_html(Heroicon::XMark, alias: TablesIconAlias::FILTERS_REMOVE_ALL_BUTTON, size: IconSize::Small) }}
+                </button>
+            @endif
+        </div>
+    @endif
+</div>

--- a/resources/views/filament/pages/board-page.blade.php
+++ b/resources/views/filament/pages/board-page.blade.php
@@ -1,5 +1,5 @@
 <x-filament-panels::page>
-    <div class="h-[calc(100vh-11rem)]">
+    <div class="h-[calc(100vh-11rem)] relative" style="z-index: 0;">
         {{ $this->board }}
     </div>
 </x-filament-panels::page>

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -16,7 +16,9 @@
     })"
 >
 
-    @include('flowforge::components.filters')
+    @unless($config['headerToolbar'] ?? false)
+        @include('flowforge::components.filters')
+    @endunless
 
     <!-- Board Content -->
     <div class="flex-1 overflow-hidden h-full">

--- a/src/Board.php
+++ b/src/Board.php
@@ -32,7 +32,7 @@ class Board extends ViewComponent
 
     protected string $evaluationIdentifier = 'board';
 
-    protected bool $headerToolbar = true;
+    protected bool $headerToolbar = false;
 
     final public function __construct(HasBoard $livewire)
     {

--- a/src/Board.php
+++ b/src/Board.php
@@ -32,6 +32,8 @@ class Board extends ViewComponent
 
     protected string $evaluationIdentifier = 'board';
 
+    protected bool $headerToolbar = false;
+
     final public function __construct(HasBoard $livewire)
     {
         $this->livewire($livewire);
@@ -45,11 +47,25 @@ class Board extends ViewComponent
         return $static;
     }
 
+    /**
+     * Move the filter/search toolbar into the page header,
+     * rendering it inline with the page title.
+     */
+    public function headerToolbar(bool $condition = true): static
+    {
+        $this->headerToolbar = $condition;
+
+        return $this;
+    }
+
+    public function hasHeaderToolbar(): bool
+    {
+        return $this->headerToolbar;
+    }
+
     protected function setUp(): void
     {
         parent::setUp();
-
-        // Any board-specific setup can go here
     }
 
     /**
@@ -87,6 +103,7 @@ class Board extends ViewComponent
                 'columnIdentifierAttribute' => $this->getColumnIdentifierAttribute(),
                 'cardLabel' => __('flowforge::flowforge.card_label'),
                 'pluralCardLabel' => __('flowforge::flowforge.plural_card_label'),
+                'headerToolbar' => $this->hasHeaderToolbar(),
             ],
         ];
     }

--- a/src/Board.php
+++ b/src/Board.php
@@ -32,7 +32,7 @@ class Board extends ViewComponent
 
     protected string $evaluationIdentifier = 'board';
 
-    protected bool $headerToolbar = false;
+    protected bool $headerToolbar = true;
 
     final public function __construct(HasBoard $livewire)
     {

--- a/src/Concerns/BaseBoard.php
+++ b/src/Concerns/BaseBoard.php
@@ -6,6 +6,7 @@ namespace Relaticle\Flowforge\Concerns;
 
 use Filament\Actions\Concerns\InteractsWithActions;
 use Filament\Forms\Concerns\InteractsWithForms;
+use Illuminate\Contracts\View\View;
 use Relaticle\Flowforge\Board;
 
 /**
@@ -31,5 +32,27 @@ trait BaseBoard
     protected function getBoardView(): string
     {
         return 'flowforge::filament.pages.board-page';
+    }
+
+    /**
+     * Override Filament's page header when headerToolbar is enabled.
+     *
+     * Renders the page title with the filter/search toolbar inline,
+     * replacing the default stacked layout.
+     */
+    public function getHeader(): ?View
+    {
+        if (! $this->getBoard()->hasHeaderToolbar()) {
+            return null;
+        }
+
+        /** @var view-string $viewName */
+        $viewName = 'flowforge::filament.pages.board-header';
+
+        return view($viewName, [
+            'heading' => $this->getHeading(),
+            'subheading' => $this->getSubheading(),
+            'breadcrumbs' => filament()->hasBreadcrumbs() ? $this->getBreadcrumbs() : [],
+        ]);
     }
 }


### PR DESCRIPTION
## Summary
- Adds `->headerToolbar()` method to `Board` that moves the filter/search toolbar inline with the page heading
- Uses Filament's native `getHeader()` override — no CSS hacking, no fighting the framework
- Active filter indicator badges render below the heading row

## Usage

```php
public function board(Board $board): Board
{
    return $board
        ->headerToolbar()  // filter + search inline with title
        ->query(...)
        ->searchable(['name'])
        ->filters([...])
        ->columns([...]);
}
```

## How it works
- `Board::headerToolbar(bool)` — sets the flag
- `BaseBoard::getHeader()` — overrides Filament's page header when enabled, rendering a custom view with title + filter + search in one row
- `index.blade.php` — skips rendering its own filter toolbar when `headerToolbar` is active (avoids duplicates)
- `board-header.blade.php` — new view that renders the combined header with proper Filament component reuse

## Default behavior unchanged
When `headerToolbar()` is not called, the board renders exactly as before — filters in their own row above the columns.

## Test plan
- [x] PHPStan passes
- [x] 112 tests pass
- [x] Pint passes
- [ ] Manual test: board with `headerToolbar()` shows filter + search next to title
- [ ] Manual test: board without `headerToolbar()` renders unchanged
- [ ] Manual test: active filters show indicator badges below heading