### PR TITLE
Header toolbar: fix spacing, persist search in URL, clean up filters

### DIFF
--- a/resources/views/filament/pages/board-header.blade.php
+++ b/resources/views/filament/pages/board-header.blade.php
@@ -1,14 +1,9 @@
 @php
-    use Filament\Support\Enums\IconSize;
     use Filament\Support\Enums\Width;
     use Filament\Support\Facades\FilamentView;
-    use Filament\Support\Icons\Heroicon;
     use Filament\Tables\Enums\FiltersLayout;
     use Filament\Tables\Filters\Indicator;
-    use Filament\Tables\View\TablesIconAlias;
     use Filament\Tables\View\TablesRenderHook;
-
-    use function Filament\Support\generate_icon_html;
 
     $table = $this->getTable();
     $isFilterable = $table->isFilterable();
@@ -32,7 +27,7 @@
     $isModalLayout = ($filtersLayout === FiltersLayout::Modal) || ($hasFiltersDialog && $filtersTriggerAction->isModalSlideOver());
 @endphp
 
-<div class="fi-page-header-main-ctn !gap-y-2 !pt-4 !pb-0">
+<div class="flex flex-col gap-y-1">
     {{-- Breadcrumbs --}}
     @if (filled($breadcrumbs))
         <x-filament::breadcrumbs :breadcrumbs="$breadcrumbs" class="mb-2" />
@@ -144,40 +139,22 @@
         @if (filled($filterIndicatorsView = FilamentView::renderHook(TablesRenderHook::FILTER_INDICATORS, scopes: static::class, data: ['filterIndicators' => $filterIndicators])))
             {{ $filterIndicatorsView }}
         @else
-            <div class="fi-ta-filter-indicators flex items-center gap-x-2">
-                <div class="flex flex-wrap items-center gap-1">
-                    @foreach ($filterIndicators as $indicator)
-                        <x-filament::badge :color="$indicator->getColor()">
-                            {{ $indicator->getLabel() }}
+            <div class="fi-ta-filter-indicators flex flex-wrap items-center gap-1 mt-1">
+                @foreach ($filterIndicators as $indicator)
+                    <x-filament::badge :color="$indicator->getColor()">
+                        {{ $indicator->getLabel() }}
 
-                            @if ($indicator->isRemovable())
-                                <x-slot
-                                    name="deleteButton"
-                                    :label="__('filament-tables::table.filters.actions.remove.label')"
-                                    :wire:click="$indicator->getRemoveLivewireClickHandler()"
-                                    wire:loading.attr="disabled"
-                                    wire:target="removeTableFilter"
-                                ></x-slot>
-                            @endif
-                        </x-filament::badge>
-                    @endforeach
-                </div>
-
-                @if (collect($filterIndicators)->contains(fn (Indicator $indicator): bool => $indicator->isRemovable()))
-                    <button
-                        type="button"
-                        x-tooltip="{
-                            content: @js(__('filament-tables::table.filters.actions.remove_all.tooltip')),
-                            theme: $store.theme,
-                        }"
-                        wire:click="removeTableFilters"
-                        wire:loading.attr="disabled"
-                        wire:target="removeTableFilters,removeTableFilter"
-                        class="fi-icon-btn fi-size-sm"
-                    >
-                        {{ generate_icon_html(Heroicon::XMark, alias: TablesIconAlias::FILTERS_REMOVE_ALL_BUTTON, size: IconSize::Small) }}
-                    </button>
-                @endif
+                        @if ($indicator->isRemovable())
+                            <x-slot
+                                name="deleteButton"
+                                :label="__('filament-tables::table.filters.actions.remove.label')"
+                                :wire:click="$indicator->getRemoveLivewireClickHandler()"
+                                wire:loading.attr="disabled"
+                                wire:target="removeTableFilter"
+                            ></x-slot>
+                        @endif
+                    </x-filament::badge>
+                @endforeach
             </div>
         @endif
     @endif

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -22,7 +22,7 @@
 
     <!-- Board Content -->
     <div class="flex-1 overflow-hidden h-full">
-        <div class="flex flex-row h-full overflow-x-auto overflow-y-hidden gap-5">
+        <div class="flex flex-row h-full overflow-x-auto overflow-y-hidden gap-x-5">
             @foreach($columns as $columnId => $column)
                 <x-flowforge::column
                     :columnId="$columnId"

--- a/src/Board.php
+++ b/src/Board.php
@@ -32,7 +32,7 @@ class Board extends ViewComponent
 
     protected string $evaluationIdentifier = 'board';
 
-    protected bool $headerToolbar = true;
+    protected bool $headerToolbar = false;
 
     final public function __construct(HasBoard $livewire)
     {

--- a/src/Board.php
+++ b/src/Board.php
@@ -32,7 +32,7 @@ class Board extends ViewComponent
 
     protected string $evaluationIdentifier = 'board';
 
-    protected bool $headerToolbar = false;
+    protected bool $headerToolbar = true;
 
     final public function __construct(HasBoard $livewire)
     {

--- a/src/BoardPage.php
+++ b/src/BoardPage.php
@@ -32,4 +32,14 @@ abstract class BoardPage extends Page implements HasActions, HasBoard, HasForms
      */
     #[Url(as: 'filters')]
     public ?array $tableFilters = null;
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    protected function queryString(): array
+    {
+        return [
+            'tableSearch' => ['as' => 'search', 'except' => ''],
+        ];
+    }
 }

--- a/src/BoardResourcePage.php
+++ b/src/BoardResourcePage.php
@@ -41,6 +41,16 @@ abstract class BoardResourcePage extends Page implements HasActions, HasBoard, H
     public ?array $tableFilters = null;
 
     /**
+     * @return array<string, array<string, mixed>>
+     */
+    protected function queryString(): array
+    {
+        return [
+            'tableSearch' => ['as' => 'search', 'except' => ''],
+        ];
+    }
+
+    /**
      * Override Filament's action resolution to detect and route board actions.
      *
      * This method intercepts the action resolution flow to check if an action


### PR DESCRIPTION
## Summary

- Fix nested `fi-page-header-main-ctn` wrapper causing board page headings to sit 18px lower than resource list pages
- Persist search query in URL (`?search=term`) matching existing filter URL persistence
- Remove redundant "remove all filters" button from indicator row (Reset in dropdown handles this)

## Changes

### Header spacing fix
The `board-header.blade.php` was wrapping content in `<div class="fi-page-header-main-ctn">` which created a nested container inside Filament's own `.fi-page-header-main-ctn` from `<x-filament-panels::page>`. This caused double padding (32px outer + 16px inner = heading at 106px vs 88px on resource pages). Replaced with a plain `flex flex-col`.

### Search URL persistence
Added `queryString()` method to `BoardPage` and `BoardResourcePage` that maps `$tableSearch` to `?search=` URL parameter. Uses Livewire's `queryString()` method (not `#[Url]` attribute) to avoid type conflict with Filament's untyped `$tableSearch` property in `CanSearchRecords` trait.

### Filter indicator cleanup
Removed the standalone "remove all" X icon button from the filter indicators row. The filter dropdown already has a "Reset" action, making the button redundant. Individual filter badge dismiss buttons are preserved.

## Test plan
- [x] Board page heading aligns with resource list page heading
- [x] Search query persists in URL when typing in search field
- [x] Filter indicators show with individual dismiss buttons
- [x] Filter dropdown Reset still clears all filters