### PR TITLE
Fix Flowforge board modal stacking context

### DIFF
--- a/resources/views/filament/pages/board-page.blade.php
+++ b/resources/views/filament/pages/board-page.blade.php
@@ -1,5 +1,5 @@
 <x-filament-panels::page>
-    <div class="h-[calc(100vh-11rem)] relative" style="z-index: 0;">
+    <div class="h-[calc(100vh-11rem)] relative">
         {{ $this->board }}
     </div>
 </x-filament-panels::page>


### PR DESCRIPTION
<img width="1450" height="733" alt="צילום מסך 2026-03-18 153811" src="https://github.com/user-attachments/assets/dc9b24de-21f7-474c-a02e-ce959827ad14" />


Issue Description
Problem: When opening Filament modals on a Flowforge board page, the modal appears behind the topbar and sidebar instead of appearing on top of all page elements. This issue only occurs on board pages and works correctly on list pages.

Root Cause: The board page template (resources/views/filament/pages/board-page.blade.php) wraps the board content in a container with style="z-index: 0;" and position: relative. This creates a new stacking context that prevents child elements (including Filament modals) from appearing above elements outside this stacking context, such as the topbar (z-index: 30) and sidebar (z-index: 30).