### PR TITLE
Add enum helper to column

### DIFF
--- a/docs/content/2.essentials/2.customization.md
+++ b/docs/content/2.essentials/2.customization.md
@@ -253,3 +253,60 @@ use Filament\Support\Colors\Color;
     Column::make('done')
         ->color('#22c55e'),                  // Custom hex
 ])
+```
+
+### Building Columns From Enums
+
+If your model already uses a backed enum for its status attribute, pass the enum
+cases directly to `Column::enum()`. The column identifier is taken from
+`$enum->value`, and Filament's `HasLabel` / `HasColor` / `HasIcon` contracts are
+applied automatically when the enum implements them.
+
+```php
+use Filament\Support\Contracts\HasColor;
+use Filament\Support\Contracts\HasIcon;
+use Filament\Support\Contracts\HasLabel;
+
+enum TaskStatus: string implements HasColor, HasIcon, HasLabel
+{
+    case Todo = 'todo';
+    case InProgress = 'in_progress';
+    case Done = 'done';
+
+    public function getLabel(): string
+    {
+        return match ($this) {
+            self::Todo => 'To Do',
+            self::InProgress => 'In Progress',
+            self::Done => 'Done',
+        };
+    }
+
+    public function getColor(): string
+    {
+        return match ($this) {
+            self::Todo => 'gray',
+            self::InProgress => 'blue',
+            self::Done => 'green',
+        };
+    }
+
+    public function getIcon(): string
+    {
+        return match ($this) {
+            self::Todo => 'heroicon-o-queue-list',
+            self::InProgress => 'heroicon-o-arrow-path',
+            self::Done => 'heroicon-o-check',
+        };
+    }
+}
+
+->columns(
+    array_map(fn (TaskStatus $status) => Column::enum($status), TaskStatus::cases()),
+)
+```
+
+Any contract your enum does not implement is simply skipped — you can start
+with `HasLabel` only and add color/icon later without changing the call site.
+Int-backed enums are supported too; the value is coerced to a string column
+identifier.

--- a/docs/content/2.essentials/4.api-reference.md
+++ b/docs/content/2.essentials/4.api-reference.md
@@ -97,6 +97,17 @@ Column::make('identifier')
     ->icon('heroicon-o-flag')                    // Column header icon
 ```
 
+### Building a column from a backed enum
+
+```php
+Column::enum(TaskStatus::Todo)                   // identifier = $enum->value
+```
+
+When the enum implements `HasLabel`, `HasColor`, or `HasIcon` those values are
+applied automatically; missing contracts are skipped. See the
+[Column Configuration guide](/essentials/customization#building-columns-from-enums)
+for a full example.
+
 ### Available Colors
 
 - `gray` - Neutral/default

--- a/src/Column.php
+++ b/src/Column.php
@@ -57,10 +57,21 @@ class Column extends ViewComponent
 
     public static function enum(BackedEnum $enum): static
     {
-        return static::make($enum->value)
-            ->label($enum instanceof \Filament\Support\Contracts\HasLabel ? $enum->getLabel() : null)
-            ->color($enum instanceof \Filament\Support\Contracts\HasColor ? $enum->getColor() : null)
-            ->icon($enum instanceof \Filament\Support\Contracts\HasIcon ? $enum->getIcon() : null);
+        $column = static::make($enum->value);
+
+        if ($enum instanceof \Filament\Support\Contracts\HasLabel) {
+            $column->label($enum->getLabel());
+        }
+
+        if ($enum instanceof \Filament\Support\Contracts\HasColor) {
+            $column->color($enum->getColor());
+        }
+
+        if ($enum instanceof \Filament\Support\Contracts\HasIcon) {
+            $column->icon($enum->getIcon());
+        }
+
+        return $column;
     }
 
     public static function getDefaultName(): ?string

--- a/src/Column.php
+++ b/src/Column.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Relaticle\Flowforge;
 
+use BackedEnum;
 use Closure;
 use Exception;
 use Filament\Support\Components\ViewComponent;
@@ -11,6 +12,9 @@ use Filament\Support\Concerns\HasColor;
 use Filament\Support\Concerns\HasIcon;
 use Filament\Support\Concerns\HasIconColor;
 use Filament\Support\Concerns\HasIconPosition;
+use Filament\Support\Contracts\HasColor as HasColorContract;
+use Filament\Support\Contracts\HasIcon as HasIconContract;
+use Filament\Support\Contracts\HasLabel;
 use Illuminate\Contracts\Support\Htmlable;
 use Relaticle\Flowforge\Concerns\BelongsToBoard;
 
@@ -55,19 +59,24 @@ class Column extends ViewComponent
         return $static;
     }
 
+    /**
+     * Build a column from a backed enum, deriving the identifier from
+     * `$enum->value` and applying Filament's enum metadata (label, color,
+     * icon) when the enum implements the corresponding contract.
+     */
     public static function enum(BackedEnum $enum): static
     {
-        $column = static::make($enum->value);
+        $column = static::make((string) $enum->value);
 
-        if ($enum instanceof \Filament\Support\Contracts\HasLabel) {
+        if ($enum instanceof HasLabel) {
             $column->label($enum->getLabel());
         }
 
-        if ($enum instanceof \Filament\Support\Contracts\HasColor) {
+        if ($enum instanceof HasColorContract) {
             $column->color($enum->getColor());
         }
 
-        if ($enum instanceof \Filament\Support\Contracts\HasIcon) {
+        if ($enum instanceof HasIconContract) {
             $column->icon($enum->getIcon());
         }
 

--- a/src/Column.php
+++ b/src/Column.php
@@ -55,6 +55,14 @@ class Column extends ViewComponent
         return $static;
     }
 
+    public static function enum(BackedEnum $enum): static
+    {
+        return static::make($enum->value)
+            ->label($enum instanceof \Filament\Support\Contracts\HasLabel ? $enum->getLabel() : null)
+            ->color($enum instanceof \Filament\Support\Contracts\HasColor ? $enum->getColor() : null)
+            ->icon($enum instanceof \Filament\Support\Contracts\HasIcon ? $enum->getIcon() : null);
+    }
+
     public static function getDefaultName(): ?string
     {
         return null;

--- a/tests/Fixtures/IntBackedEnum.php
+++ b/tests/Fixtures/IntBackedEnum.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\Flowforge\Tests\Fixtures;
+
+enum IntBackedEnum: int
+{
+    case First = 1;
+    case Second = 2;
+}

--- a/tests/Fixtures/LabelOnlyEnum.php
+++ b/tests/Fixtures/LabelOnlyEnum.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\Flowforge\Tests\Fixtures;
+
+use Filament\Support\Contracts\HasLabel;
+
+enum LabelOnlyEnum: string implements HasLabel
+{
+    case Draft = 'draft';
+
+    public function getLabel(): string
+    {
+        return 'Draft Item';
+    }
+}

--- a/tests/Fixtures/PlainEnum.php
+++ b/tests/Fixtures/PlainEnum.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\Flowforge\Tests\Fixtures;
+
+enum PlainEnum: string
+{
+    case Archived = 'archived';
+}

--- a/tests/Fixtures/StatusEnum.php
+++ b/tests/Fixtures/StatusEnum.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\Flowforge\Tests\Fixtures;
+
+use Filament\Support\Contracts\HasColor;
+use Filament\Support\Contracts\HasIcon;
+use Filament\Support\Contracts\HasLabel;
+
+enum StatusEnum: string implements HasColor, HasIcon, HasLabel
+{
+    case Active = 'active';
+    case Pending = 'pending';
+
+    public function getLabel(): string
+    {
+        return match ($this) {
+            self::Active => 'Active Item',
+            self::Pending => 'Pending Item',
+        };
+    }
+
+    public function getColor(): string
+    {
+        return match ($this) {
+            self::Active => 'success',
+            self::Pending => 'warning',
+        };
+    }
+
+    public function getIcon(): string
+    {
+        return match ($this) {
+            self::Active => 'heroicon-o-check',
+            self::Pending => 'heroicon-o-clock',
+        };
+    }
+}

--- a/tests/Unit/ColumnEnumTest.php
+++ b/tests/Unit/ColumnEnumTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+use Relaticle\Flowforge\Column;
+use Relaticle\Flowforge\Tests\Fixtures\IntBackedEnum;
+use Relaticle\Flowforge\Tests\Fixtures\LabelOnlyEnum;
+use Relaticle\Flowforge\Tests\Fixtures\PlainEnum;
+use Relaticle\Flowforge\Tests\Fixtures\StatusEnum;
+
+describe('Column::enum()', function () {
+    test('builds a column from an enum implementing HasLabel, HasColor, and HasIcon', function () {
+        $column = Column::enum(StatusEnum::Active);
+
+        expect($column->getName())->toBe('active')
+            ->and($column->getLabel())->toBe('Active Item')
+            ->and($column->getColor())->toBe('success')
+            ->and($column->getIcon())->toBe('heroicon-o-check');
+    });
+
+    test('applies only the interfaces the enum implements', function () {
+        $column = Column::enum(LabelOnlyEnum::Draft);
+
+        expect($column->getName())->toBe('draft')
+            ->and($column->getLabel())->toBe('Draft Item')
+            ->and($column->getColor())->toBeNull()
+            ->and($column->getIcon())->toBeNull();
+    });
+
+    test('falls back to generated defaults for an enum without any Filament contracts', function () {
+        $column = Column::enum(PlainEnum::Archived);
+
+        expect($column->getName())->toBe('archived')
+            ->and($column->getLabel())->toBe('Archived')
+            ->and($column->getColor())->toBeNull()
+            ->and($column->getIcon())->toBeNull();
+    });
+
+    test('casts int-backed enum values to string for the column identifier', function () {
+        $column = Column::enum(IntBackedEnum::First);
+
+        expect($column->getName())->toBe('1')
+            ->and($column->getName())->toBeString();
+    });
+});


### PR DESCRIPTION
A helper method to the Column class to set column properties directly from an enum.

Allows a config like this and will set the column label, icon and colour if the standard interfaces are setup.

```
 ->columns([
                Column::enum(State::OPEN),
                Column::enum(State::WAITING),
                Column::enum(State::CLOSED),
            ]);
```