### PR TITLE
fix: update dependencies to resolve critical security vulnerabilities [3.x]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
     "requires": true,
     "packages": {
         "": {
+            "name": "flowforge",
             "devDependencies": {
                 "@awcodes/filament-plugin-purge": "^1.1.2",
                 "@tailwindcss/cli": "^4.1.10",
@@ -1294,15 +1295,15 @@
             }
         },
         "node_modules/axios": {
-            "version": "1.12.2",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
-            "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
+            "version": "1.15.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+            "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "follow-redirects": "^1.15.6",
-                "form-data": "^4.0.4",
-                "proxy-from-env": "^1.1.0"
+                "follow-redirects": "^1.15.11",
+                "form-data": "^4.0.5",
+                "proxy-from-env": "^2.1.0"
             }
         },
         "node_modules/balanced-match": {
@@ -1346,9 +1347,9 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+            "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2007,9 +2008,9 @@
             }
         },
         "node_modules/form-data": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-            "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+            "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2281,9 +2282,9 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/immutable": {
-            "version": "5.1.3",
-            "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.3.tgz",
-            "integrity": "sha512-+chQdDfvscSF1SJqv2gn4SRO2ZyS3xL3r7IW/wWEEzrzLisnOlKiQu5ytC/BVNcS15C39WT2Hg/bjKjDMcu+zg==",
+            "version": "5.1.5",
+            "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
+            "integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
             "dev": true,
             "license": "MIT"
         },
@@ -3140,9 +3141,9 @@
             }
         },
         "node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -3426,9 +3427,9 @@
             "license": "ISC"
         },
         "node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3746,11 +3747,14 @@
             }
         },
         "node_modules/proxy-from-env": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+            "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            }
         },
         "node_modules/read-pkg": {
             "version": "3.0.0",
@@ -4391,11 +4395,11 @@
             }
         },
         "node_modules/tar": {
-            "version": "7.5.1",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.1.tgz",
-            "integrity": "sha512-nlGpxf+hv0v7GkWBK2V9spgactGOp0qvfWRxUMjqHyzrt3SgwE48DIv/FhqPHJYLHpgW1opq3nERbz5Anq7n1g==",
+            "version": "7.5.13",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
+            "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
             "dev": true,
-            "license": "ISC",
+            "license": "BlueOak-1.0.0",
             "dependencies": {
                 "@isaacs/fs-minipass": "^4.0.0",
                 "chownr": "^3.0.0",


### PR DESCRIPTION
## Summary

- Update axios to 1.15.0 (critical SSRF bypass + DoS via `__proto__`)
- Update brace-expansion to fix process hang vulnerability
- Update immutable to fix prototype pollution vulnerability

All fixes applied via `npm audit fix`.