### PR TITLE
ci: make release workflow idempotent [4.x]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,23 +18,29 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Determine if pre-release
-        id: prerelease
+      - name: Determine release flags
+        id: flags
+        env:
+          TAG: ${{ github.ref_name }}
         run: |
-          TAG="${{ github.ref_name }}"
           if [[ "$TAG" == *"-"* ]]; then
-            echo "flag=--prerelease" >> $GITHUB_OUTPUT
+            echo "prerelease=--prerelease" >> "$GITHUB_OUTPUT"
           else
-            echo "flag=" >> $GITHUB_OUTPUT
+            echo "prerelease=" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Create GitHub Release
-        run: gh release create "${{ github.ref_name }}" --generate-notes ${{ steps.prerelease.outputs.flag }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ github.ref_name }}
+          PRERELEASE_FLAG: ${{ steps.flags.outputs.prerelease }}
+        run: |
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists, skipping creation."
+            exit 0
+          fi
+          gh release create "$TAG" --generate-notes $PRERELEASE_FLAG
 
   cleanup:
     needs: tests
@@ -44,8 +50,9 @@ jobs:
       contents: write
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
       - name: Delete tag on test failure
-        run: git push --delete origin "${{ github.ref_name }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ github.ref_name }}
+        run: gh api -X DELETE "repos/$GH_REPO/git/refs/tags/$TAG"


### PR DESCRIPTION
## Summary

The release workflow has been failing whenever a release is authored manually in the GitHub UI (or via `gh release create` locally). Manual release creation auto-creates the tag, which triggers `release.yml`, which then re-runs `gh release create` and fails with:

```
HTTP 422: Validation Failed
Release.tag_name already exists
```

Recent failures: v4.0.7, v4.0.8 (twice), v4.0.11. Runs that succeeded (v4.0.9, v4.0.10) were ones where only a tag was pushed and the workflow itself created the release.

## Changes

- **Idempotent release creation** — skip `gh release create` when a release for the tag already exists. Tests still run as a gate, so manually-published releases are still validated.
- **Drop redundant `actions/checkout`** from both `release` and `cleanup` jobs. `gh release create --generate-notes` queries the GitHub API and doesn't need a local checkout; same for tag deletion.
- **Use `gh api DELETE` for cleanup** instead of `git push --delete`. Removes the implicit dependency on having a working tree set up.

## Test plan

- [ ] Next release (manually authored or tag-only) does not fail this workflow.
- [ ] When tests fail, the cleanup job successfully deletes the tag.