### PR TITLE
fix: pass 'column' argument to CreateAction mutateDataUsing

### DIFF
--- a/docs/content/2.essentials/2.customization.md
+++ b/docs/content/2.essentials/2.customization.md
@@ -108,7 +108,7 @@ public function board(Board $board): Board
                         ->options(['low' => 'Low', 'medium' => 'Medium', 'high' => 'High'])
                         ->default('medium'),
                 ])
-                ->mutateFormDataUsing(function (array $data, array $arguments): array {
+                ->mutateDataUsing(function (array $data, array $arguments): array {
                     if (isset($arguments['column'])) {
                         $data['status'] = $arguments['column'];
                         $data['position'] = $this->getBoardPositionInColumn($arguments['column']);

--- a/docs/content/2.essentials/5.troubleshooting.md
+++ b/docs/content/2.essentials/5.troubleshooting.md
@@ -85,7 +85,7 @@ class TaskBoard extends BoardPage
 
 ```php
 CreateAction::make()
-    ->mutateFormDataUsing(function (array $data, array $arguments): array {
+    ->mutateDataUsing(function (array $data, array $arguments): array {
         if (isset($arguments['column'])) {
             $data['status'] = $arguments['column'];
             $data['position'] = $this->getBoardPositionInColumn($arguments['column']);

--- a/src/BoardResourcePage.php
+++ b/src/BoardResourcePage.php
@@ -9,6 +9,7 @@ use Filament\Actions\Contracts\HasActions;
 use Filament\Actions\Exceptions\ActionNotResolvableException;
 use Filament\Forms\Contracts\HasForms;
 use Filament\Resources\Pages\Page;
+use Filament\Tables\Contracts\HasTable;
 use Livewire\Attributes\Url;
 use Relaticle\Flowforge\Concerns\BaseBoard;
 use Relaticle\Flowforge\Concerns\InteractsWithBoard;
@@ -86,7 +87,7 @@ abstract class BoardResourcePage extends Page implements HasActions, HasBoard, H
                 $resolvedAction = $this->resolveBoardAction($action, $resolvedActions);
             } elseif (filled($action['context']['schemaComponent'] ?? null)) {
                 $resolvedAction = $this->resolveSchemaComponentAction($action, $resolvedActions);
-            } elseif (filled($action['context']['table'] ?? null)) {
+            } elseif ($this instanceof HasTable && filled($action['context']['table'] ?? null)) {
                 $resolvedAction = $this->resolveTableAction($action, $resolvedActions);
             } else {
                 $resolvedAction = $this->resolveAction($action, $resolvedActions);
@@ -96,15 +97,21 @@ abstract class BoardResourcePage extends Page implements HasActions, HasBoard, H
                 continue;
             }
 
+            if (filled($action['arguments'] ?? [])) {
+                $resolvedAction->mergeArguments($action['arguments']);
+            }
+
             $resolvedAction->nestingIndex($actionNestingIndex);
             $resolvedAction->boot();
 
             $resolvedActions[] = $resolvedAction;
 
-            $this->cacheSchema(
-                "mountedActionSchema{$actionNestingIndex}",
-                $this->getMountedActionSchema($actionNestingIndex, $resolvedAction),
-            );
+            if ($isMounting) {
+                $this->cacheSchema(
+                    "mountedActionSchema{$actionNestingIndex}",
+                    $this->getMountedActionSchema($actionNestingIndex, $resolvedAction),
+                );
+            }
         }
 
         return $resolvedActions;

--- a/tests/Feature/BoardResourcePageColumnActionTest.php
+++ b/tests/Feature/BoardResourcePageColumnActionTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+use Filament\Actions\Testing\TestAction;
+use Livewire\Livewire;
+use Relaticle\Flowforge\Tests\Fixtures\Task;
+use Relaticle\Flowforge\Tests\Fixtures\TestBoardResourcePage;
+
+test('column action receives column argument in mutateDataUsing', function () {
+    Livewire::test(TestBoardResourcePage::class)
+        ->callAction(
+            TestAction::make('createTask')->arguments(['column' => 'in_progress']),
+            ['title' => 'New Task'],
+        );
+
+    $task = Task::where('title', 'New Task')->firstOrFail();
+
+    expect($task->status)->toBe('in_progress');
+});

--- a/tests/Fixtures/TestBoardResourcePage.php
+++ b/tests/Fixtures/TestBoardResourcePage.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\Flowforge\Tests\Fixtures;
+
+use Filament\Actions\CreateAction;
+use Filament\Forms\Components\TextInput;
+use Illuminate\Database\Eloquent\Builder;
+use Relaticle\Flowforge\Board;
+use Relaticle\Flowforge\BoardResourcePage;
+use Relaticle\Flowforge\Column;
+
+class TestBoardResourcePage extends BoardResourcePage
+{
+    protected static string $resource = TestResource::class;
+
+    public function getEloquentQuery(): Builder
+    {
+        return Task::query();
+    }
+
+    public function board(Board $board): Board
+    {
+        return $board
+            ->query($this->getEloquentQuery())
+            ->recordTitleAttribute('title')
+            ->columnIdentifier('status')
+            ->positionIdentifier('order_position')
+            ->columns([
+                Column::make('todo')->label('To Do'),
+                Column::make('in_progress')->label('In Progress'),
+                Column::make('completed')->label('Completed'),
+            ])
+            ->columnActions([
+                CreateAction::make('createTask')
+                    ->model(Task::class)
+                    ->schema([
+                        TextInput::make('title')->required(),
+                    ])
+                    ->mutateDataUsing(function (array $data, array $arguments): array {
+                        $data['status'] = $arguments['column'] ?? 'todo';
+
+                        return $data;
+                    }),
+            ]);
+    }
+}

--- a/tests/Fixtures/TestPanelProvider.php
+++ b/tests/Fixtures/TestPanelProvider.php
@@ -29,6 +29,9 @@ class TestPanelProvider extends PanelProvider
             ->pages([
                 TestBoard::class,
             ])
+            ->resources([
+                TestResource::class,
+            ])
             ->middleware([
                 EncryptCookies::class,
                 AddQueuedCookiesToResponse::class,

--- a/tests/Fixtures/TestResource.php
+++ b/tests/Fixtures/TestResource.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\Flowforge\Tests\Fixtures;
+
+use Filament\Resources\Resource;
+
+class TestResource extends Resource
+{
+    protected static ?string $model = Task::class;
+
+    protected static bool $shouldCheckPolicyExistence = false;
+
+    protected static bool $shouldSkipAuthorization = true;
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => TestBoardResourcePage::route('/'),
+        ];
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -11,6 +11,7 @@ use Filament\FilamentServiceProvider;
 use Filament\Forms\FormsServiceProvider;
 use Filament\Infolists\InfolistsServiceProvider;
 use Filament\Notifications\NotificationsServiceProvider;
+use Filament\Schemas\SchemasServiceProvider;
 use Filament\Support\SupportServiceProvider;
 use Filament\Tables\TablesServiceProvider;
 use Filament\Widgets\WidgetsServiceProvider;
@@ -48,6 +49,7 @@ class TestCase extends Orchestra
             InfolistsServiceProvider::class,
             LivewireServiceProvider::class,
             NotificationsServiceProvider::class,
+            SchemasServiceProvider::class,
             SupportServiceProvider::class,
             TablesServiceProvider::class,
             WidgetsServiceProvider::class,


### PR DESCRIPTION
**What does this PR do?**
This PR fixes an issue where the `column` argument was missing from the `$arguments` array in the `CreateAction`'s `mutateDataUsing` method. 

**Why is this needed?**
The package documentation implies that when triggering a `CreateAction` from a specific column in the BoardResourcePage board, the developer should be able to capture the column's identifier to automatically assign the status/column ID to the new record. 

Without this fix, `$arguments['column']` is undefined, requiring workarounds.

**Example of what is now possible:**
```php
CreateAction::make()
    ->mutateDataUsing(function (array $data, array $arguments) {
        if (isset($arguments['column'])) {
            $data['task_status_id'] = $arguments['column'];
        }
        return $data;
    })
```

**Checklist:**
- [x] I have tested this code in my own project.
- [x] The code follows the existing style of the project.