### PR TITLE
fix: resolve nested schema component actions inside card actions

### DIFF
--- a/src/BoardResourcePage.php
+++ b/src/BoardResourcePage.php
@@ -62,6 +62,13 @@ abstract class BoardResourcePage extends Page implements HasActions, HasBoard, H
      * This mirrors the logic in InteractsWithActions::resolveActions() but adds
      * board action detection.
      *
+     * Board detection runs AFTER schema and table detection, because those contexts
+     * are more specific. Filament adds `recordKey` to the context of any action that
+     * has a record, so a schema component action nested inside a mounted card action
+     * (a Repeater's add button, for instance) inherits the card's record and arrives
+     * with both keys set. Checking `recordKey` first would send it to the board
+     * resolver, which cannot find it, silently dropping the mounted entry.
+     *
      * @param  array<array<string, mixed>>  $actions
      * @return array<Action>
      *
@@ -76,19 +83,17 @@ abstract class BoardResourcePage extends Page implements HasActions, HasBoard, H
                 throw new ActionNotResolvableException('An action tried to resolve without a name.');
             }
 
-            // Check if this is a board CARD action (has recordKey in context)
-            // Column actions have 'column' in arguments, not recordKey
-            // This detection happens BEFORE schema/table action detection
+            // A board CARD action carries recordKey in its context. Column actions
+            // carry 'column' in their arguments instead, and are resolved normally.
             $recordKey = $action['context']['recordKey'] ?? null;
             $columnId = $action['arguments']['column'] ?? null;
 
-            // Only route to resolveBoardAction for card actions (not column actions)
-            if (filled($recordKey) && blank($columnId)) {
-                $resolvedAction = $this->resolveBoardAction($action, $resolvedActions);
-            } elseif (filled($action['context']['schemaComponent'] ?? null)) {
+            if (filled($action['context']['schemaComponent'] ?? null)) {
                 $resolvedAction = $this->resolveSchemaComponentAction($action, $resolvedActions);
             } elseif ($this instanceof HasTable && filled($action['context']['table'] ?? null)) {
                 $resolvedAction = $this->resolveTableAction($action, $resolvedActions);
+            } elseif (filled($recordKey) && blank($columnId)) {
+                $resolvedAction = $this->resolveBoardAction($action, $resolvedActions);
             } else {
                 $resolvedAction = $this->resolveAction($action, $resolvedActions);
             }

--- a/tests/Feature/BoardResourcePageNestedActionTest.php
+++ b/tests/Feature/BoardResourcePageNestedActionTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+use Livewire\Livewire;
+use Relaticle\Flowforge\Tests\Fixtures\Task;
+use Relaticle\Flowforge\Tests\Fixtures\TestBoardResourcePage;
+
+/**
+ * A schema component action nested inside a mounted card action (for example a
+ * Repeater's add/delete button) inherits the card's record, so Filament gives it a
+ * context carrying BOTH `recordKey` and `schemaComponent`. Routing on `recordKey`
+ * first sends it to the board resolver, which cannot find it, silently dropping the
+ * mounted entry: the modal closes and the board never recovers.
+ *
+ * @see https://github.com/relaticle/flowforge/issues/156
+ */
+test('repeater add action inside a card action keeps the card action mounted', function () {
+    $task = Task::factory()->create(['status' => 'todo']);
+
+    $component = Livewire::test(TestBoardResourcePage::class)
+        ->call('mountAction', 'editTask', [], ['recordKey' => $task->getKey()]);
+
+    expect($component->get('mountedActions'))->toHaveCount(1);
+
+    $itemsBefore = count($component->get('mountedActions.0.data.items'));
+
+    $component->call('mountAction', 'add', [], [
+        'recordKey' => $task->getKey(),
+        'schemaComponent' => 'mountedActionSchema0.items',
+    ]);
+
+    expect($component->get('mountedActions'))->toHaveCount(1)
+        ->and($component->get('mountedActions.0.name'))->toBe('editTask')
+        ->and($component->get('mountedActions.0.data.items'))->toHaveCount($itemsBefore + 1);
+});
+
+test('repeater delete action inside a card action keeps the card action mounted', function () {
+    $task = Task::factory()->create(['status' => 'todo']);
+
+    $component = Livewire::test(TestBoardResourcePage::class)
+        ->call('mountAction', 'editTask', [], ['recordKey' => $task->getKey()]);
+
+    $items = $component->get('mountedActions.0.data.items');
+    $itemKey = array_key_first($items);
+
+    $component->call('mountAction', 'delete', ['item' => $itemKey], [
+        'recordKey' => $task->getKey(),
+        'schemaComponent' => 'mountedActionSchema0.items',
+    ]);
+
+    expect($component->get('mountedActions'))->toHaveCount(1)
+        ->and($component->get('mountedActions.0.name'))->toBe('editTask')
+        ->and($component->get('mountedActions.0.data.items'))->toHaveCount(count($items) - 1);
+});
+
+test('card actions stay mountable after a nested schema component action runs', function () {
+    $task = Task::factory()->create(['status' => 'todo']);
+
+    $component = Livewire::test(TestBoardResourcePage::class)
+        ->call('mountAction', 'editTask', [], ['recordKey' => $task->getKey()])
+        ->call('mountAction', 'add', [], [
+            'recordKey' => $task->getKey(),
+            'schemaComponent' => 'mountedActionSchema0.items',
+        ])
+        ->call('unmountAction')
+        ->call('mountAction', 'editTask', [], ['recordKey' => $task->getKey()]);
+
+    expect($component->get('mountedActions'))->toHaveCount(1)
+        ->and($component->get('mountedActions.0.name'))->toBe('editTask');
+});
+
+test('card action still resolves its record', function () {
+    $task = Task::factory()->create(['status' => 'todo', 'title' => 'Resolve me']);
+
+    $component = Livewire::test(TestBoardResourcePage::class)
+        ->call('mountAction', 'editTask', [], ['recordKey' => $task->getKey()]);
+
+    expect($component->instance()->getMountedAction()->getRecord()?->getKey())->toBe($task->getKey());
+});

--- a/tests/Feature/BoardResourcePageNestedActionTest.php
+++ b/tests/Feature/BoardResourcePageNestedActionTest.php
@@ -70,6 +70,23 @@ test('card actions stay mountable after a nested schema component action runs', 
         ->and($component->get('mountedActions.0.name'))->toBe('editTask');
 });
 
+/**
+ * A modal action registered on a card action has a parent action, so Filament's
+ * getContext() returns early with only `recordKey`. It must keep resolving through
+ * resolveBoardAction() and its getModalAction() lookup.
+ */
+test('modal actions registered on a card action still resolve through the board resolver', function () {
+    $task = Task::factory()->create(['status' => 'todo']);
+
+    $component = Livewire::test(TestBoardResourcePage::class)
+        ->call('mountAction', 'editTask', [], ['recordKey' => $task->getKey()])
+        ->call('mountAction', 'nestedModalAction', [], ['recordKey' => $task->getKey()]);
+
+    expect($component->get('mountedActions'))->toHaveCount(2)
+        ->and(array_column($component->get('mountedActions'), 'name'))
+        ->toBe(['editTask', 'nestedModalAction']);
+});
+
 test('card action still resolves its record', function () {
     $task = Task::factory()->create(['status' => 'todo', 'title' => 'Resolve me']);
 

--- a/tests/Fixtures/TestBoardResourcePage.php
+++ b/tests/Fixtures/TestBoardResourcePage.php
@@ -55,6 +55,11 @@ class TestBoardResourcePage extends BoardResourcePage
                                 TextInput::make('name'),
                             ]),
                     ])
+                    ->registerModalActions([
+                        Action::make('nestedModalAction')
+                            ->requiresConfirmation()
+                            ->action(function (): void {}),
+                    ])
                     ->action(function (): void {}),
             ]);
     }

--- a/tests/Fixtures/TestBoardResourcePage.php
+++ b/tests/Fixtures/TestBoardResourcePage.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Relaticle\Flowforge\Tests\Fixtures;
 
+use Filament\Actions\Action;
 use Filament\Actions\CreateAction;
+use Filament\Forms\Components\Repeater;
 use Filament\Forms\Components\TextInput;
 use Illuminate\Database\Eloquent\Builder;
 use Relaticle\Flowforge\Board;
@@ -43,6 +45,17 @@ class TestBoardResourcePage extends BoardResourcePage
 
                         return $data;
                     }),
+            ])
+            ->cardActions([
+                Action::make('editTask')
+                    ->schema([
+                        TextInput::make('title'),
+                        Repeater::make('items')
+                            ->schema([
+                                TextInput::make('name'),
+                            ]),
+                    ])
+                    ->action(function (): void {}),
             ]);
     }
 }


### PR DESCRIPTION
Fixes #156.

## The bug

With an `EditAction` in `cardActions()` whose schema contains a `Repeater`, clicking the repeater's add (or remove) button closes the modal without applying the change. Afterwards no card action responds to clicks until the page is reloaded.

## Root cause

`Filament\Actions\Action::getContext()` adds `recordKey` to the context of **any** action that has a record. A schema component action nested inside a mounted card action inherits the card's record, so it arrives with **both** keys set:

```
mountAction('add', {}, { recordKey: "01kxkp4y…", schemaComponent: "mountedActionSchema0.items" })
```

`BoardResourcePage::resolveActions()` checked `recordKey` first, so the entry was routed to `resolveBoardAction()` → `$parentAction->getModalAction('add')` → `null` → `continue`. The mounted entry was silently dropped (no exception, nothing logged).

Both reported symptoms follow from that one dropped entry:

- `mountedActions` holds 2 entries but only 1 resolves, so `syncActionModals()` targets a nesting index that was never rendered and the open modal closes.
- The orphaned entry is never popped, so `getMountedAction()` can never match `count($mountedActions) - 1` again. Every later card click appends another unreachable entry (`["edit", "add", "edit"]`), and nothing opens until reload.

Filament core checks `schemaComponent` and `table` **before** falling back, so this is a divergence from upstream ordering rather than a new rule.

## The fix

Check `schemaComponent` and `table` before `recordKey`, matching `InteractsWithActions::resolveActions()`. Board card actions still route to `resolveBoardAction()`; they simply no longer shadow the more specific contexts.

This also covers the repeater's delete/reorder/clone actions and every other nested schema component action inside a card action modal (Builder, `Select::createOptionAction()`, nested `->schema()` modals). `BoardPage` was never affected, it has no override.

## Backward compatibility

The reorder only changes routing for entries whose context has `recordKey` **and** `schemaComponent` or `table`. Everything else takes the same branch as before.

- Card actions never carry `schemaComponent` or `table`. They are built by `getBoardRecordActions()`, which sets only `livewire()` and `record()`, and `Action::getTable()` resolves from `$this->table ?? $this->getGroup()?->getTable()`, both null here. Confirmed against a running board: a mounted card action's context is `{recordKey}` and nothing else.
- Modal actions registered on a card action are unaffected. `getContext()` returns early once an action has a parent action, so they carry only `recordKey` and keep resolving through `resolveBoardAction()`'s `getModalAction()` lookup. Covered by a dedicated test that passes both before and after the change.
- Column actions are untouched, they are detected by the `column` argument. The existing `BoardResourcePageColumnActionTest` still passes.
- The entries whose routing does change (top-level schema component actions, and table actions on a page that also implements `HasTable`) previously resolved to `null` and were dropped, so there is no working behaviour to preserve.

## Test plan

Five tests in `tests/Feature/BoardResourcePageNestedActionTest.php`, driven through `TestBoardResourcePage` (a real `BoardResourcePage` with a `Repeater` in a card action):

- repeater add keeps the card action mounted and increments the item count
- repeater delete keeps the card action mounted and decrements the item count
- card actions are still mountable after a nested action has run (the freeze)
- the card action still resolves its record (guards the behaviour the override exists for)
- modal actions registered on a card action still resolve through the board resolver (the backward-compatibility guard above)

Three of the five fail on `4.x` with `Failed asserting that actual size 2 matches expected size 1`, which is the orphaned entry. The other two pass before and after, which is the point of them. All five pass with the fix.

Verified locally beyond the test suite:

- `vendor/bin/pest`: 152 passed
- `vendor/bin/pint`: passed
- `vendor/bin/phpstan analyse`: 7 errors, identical to the count on unmodified `4.x` (pre-existing, none in the changed code)
- Browser check in a real Filament 5.4 app: repeater add 1 → 2 items with the modal still open, repeater delete 2 → 1 with the modal still open, `mountedActions` stays at a single entry, and a card action mounts normally afterwards