### PR TITLE
fix: render cards as native links when the card action has a url

### DIFF
--- a/docs/content/2.essentials/4.api-reference.md
+++ b/docs/content/2.essentials/4.api-reference.md
@@ -82,10 +82,19 @@ address" work as expected:
 ->cardAction('view')
 ```
 
-A modal wins over a url. If the action also declares `->requiresConfirmation()`, a custom
-modal heading, description or content, the card keeps opening that modal, because a whole
-card is an easy target to click by accident. An action that only inherits a url from the
-page's `getDefaultActionUrl()`, without its own `->url()`, also keeps opening its modal.
+A url decides, exactly as it does for a table row. Filament's `ListRecords` builds
+`recordUrl()` from the first `view`/`edit` action whose `getUrl()` is filled and has
+`recordAction()` skip those same actions, without consulting their modal state. A card
+follows that rule, so the same action behaves the same way in a board and in a table.
+
+Two consequences worth knowing:
+
+- An action declaring both a url and a modal (`->requiresConfirmation()`, a custom modal
+  heading, a schema) renders as a link and never opens that modal. Filament's own table
+  row and actions dropdown do the same. Pick one or the other.
+- A url inherited from the page's `getDefaultActionUrl()` counts, since `getUrl()`
+  consults it. Only `->postToUrl()` actions stay on the click handler, because a POST
+  needs a form rather than an anchor.
 
 ### Search & Filtering
 

--- a/docs/content/2.essentials/4.api-reference.md
+++ b/docs/content/2.essentials/4.api-reference.md
@@ -82,6 +82,11 @@ address" work as expected:
 ->cardAction('view')
 ```
 
+A modal wins over a url. If the action also declares `->requiresConfirmation()`, a custom
+modal heading, description or content, the card keeps opening that modal, because a whole
+card is an easy target to click by accident. An action that only inherits a url from the
+page's `getDefaultActionUrl()`, without its own `->url()`, also keeps opening its modal.
+
 ### Search & Filtering
 
 ```php

--- a/docs/content/2.essentials/4.api-reference.md
+++ b/docs/content/2.essentials/4.api-reference.md
@@ -69,6 +69,19 @@ public function board(Board $board): Board
 ->cardAction('edit')                              // Make cards clickable
 ```
 
+`cardAction()` takes the name of an action registered in `cardActions()`. When that
+action is configured with `->url()`, the card renders as a native link (respecting
+`->openUrlInNewTab()`) instead of opening a modal, so middle-click and "copy link
+address" work as expected:
+
+```php
+->cardActions([
+    Action::make('view')
+        ->url(fn (Task $record): string => TaskResource::getUrl('view', ['record' => $record])),
+])
+->cardAction('view')
+```
+
 ### Search & Filtering
 
 ```php

--- a/resources/views/livewire/card.blade.php
+++ b/resources/views/livewire/card.blade.php
@@ -9,10 +9,17 @@
 
     // A card action configured with ->url() must navigate like a native link instead
     // of mounting a modal, so middle-click, cmd-click and "copy link" keep working.
-    // getUrl() returns null when the action has a modal, and POST urls need a form
+    //
+    // Only an explicitly configured url opts a card into link rendering. getUrl()
+    // also falls back to the livewire component's getDefaultActionUrl(), which
+    // Filament's resource pages implement for modal-less Create/Edit/View actions;
+    // honouring that here would silently turn existing boards into links. getUrl()
+    // still returns null when the action has a modal, and POST urls need a form
     // rather than an anchor, so both fall through to the Livewire click handler.
     $cardActionInstance = $this->getBoard()->resolveCardAction($processedRecordActions);
-    $cardActionUrl = $cardActionInstance?->shouldPostToUrl() ? null : $cardActionInstance?->getUrl();
+    $cardActionUrl = ($cardActionInstance?->hasUrl() && ! $cardActionInstance->shouldPostToUrl())
+        ? $cardActionInstance->getUrl()
+        : null;
     $hasCardActionUrl = filled($cardActionUrl);
     $cardActionHref = $hasCardActionUrl
         ? \Filament\Support\generate_href_html(

--- a/resources/views/livewire/card.blade.php
+++ b/resources/views/livewire/card.blade.php
@@ -7,26 +7,21 @@
     $hasCardAction = $cardAction !== null;
     $hasPositionIdentifier = $this->getBoard()->getPositionIdentifierAttribute() !== null;
 
-    // A card action configured with ->url() must navigate like a native link instead
-    // of mounting a modal, so middle-click, cmd-click and "copy link" keep working.
+    // A card action configured with a url must navigate like a native link instead of
+    // mounting a modal, so middle-click, cmd-click and "copy link" keep working.
     //
-    // Three conditions keep an action on the Livewire click handler instead:
+    // The rule is Filament's own, taken from ListRecords::table(): a url on the action
+    // decides. There, recordAction() skips any action whose getUrl() is filled and
+    // recordUrl() takes it instead, with no check of the action's modal state. An
+    // action carrying both a url and a confirmation therefore renders as a plain link
+    // in core too. Mirroring that keeps a board card and a table row behaving the same
+    // way for the same action, which matters more than second-guessing the config.
     //
-    // - No explicit ->url(). getUrl() also falls back to the livewire component's
-    //   getDefaultActionUrl(), which Filament's resource pages implement for
-    //   modal-less Create/Edit/View actions; honouring that here would silently turn
-    //   existing boards into links. hasUrl() makes link rendering opt-in.
-    // - The action opens a modal. hasModal() only reports an explicit ->modal()
-    //   call, so it does not cover ->requiresConfirmation() or a custom modal
-    //   heading; shouldOpenModal() does. A whole card is a large accidental-click
-    //   target, so a configured confirmation step always wins over a url.
-    // - The url is posted to, which needs a form rather than an anchor.
+    // Only POST urls are excluded: those need a form rather than an anchor.
     $cardActionInstance = $this->getBoard()->resolveCardAction($processedRecordActions);
-    $cardActionUrl = ($cardActionInstance?->hasUrl()
-        && ! $cardActionInstance->shouldOpenModal()
-        && ! $cardActionInstance->shouldPostToUrl())
-            ? $cardActionInstance->getUrl()
-            : null;
+    $cardActionUrl = $cardActionInstance?->shouldPostToUrl()
+        ? null
+        : $cardActionInstance?->getUrl();
     $hasCardActionUrl = filled($cardActionUrl);
     $cardActionHref = $hasCardActionUrl
         ? \Filament\Support\generate_href_html(

--- a/resources/views/livewire/card.blade.php
+++ b/resources/views/livewire/card.blade.php
@@ -6,6 +6,21 @@
     $cardAction = $this->getBoard()->getCardAction();
     $hasCardAction = $cardAction !== null;
     $hasPositionIdentifier = $this->getBoard()->getPositionIdentifierAttribute() !== null;
+
+    // A card action configured with ->url() must navigate like a native link instead
+    // of mounting a modal, so middle-click, cmd-click and "copy link" keep working.
+    // getUrl() returns null when the action has a modal, and POST urls need a form
+    // rather than an anchor, so both fall through to the Livewire click handler.
+    $cardActionInstance = $this->getBoard()->resolveCardAction($processedRecordActions);
+    $cardActionUrl = $cardActionInstance?->shouldPostToUrl() ? null : $cardActionInstance?->getUrl();
+    $hasCardActionUrl = filled($cardActionUrl);
+    $cardActionHref = $hasCardActionUrl
+        ? \Filament\Support\generate_href_html(
+            $cardActionUrl,
+            $cardActionInstance->shouldOpenUrlInNewTab(),
+            hasNestedClickEventHandler: true,
+        )
+        : null;
 @endphp
 
 <div
@@ -26,12 +41,18 @@
     <div class="flowforge-card-content">
         <div class="flex items-start justify-between mb-2">
             <h4 class="text-sm font-semibold text-gray-900 dark:text-white p-3"
-                @if($hasCardAction && $cardAction)
+                @if($hasCardAction && $cardAction && !$hasCardActionUrl)
                     wire:click="mountAction('{{ $cardAction }}', [], @js(['recordKey' => $record['id']]))"
                 style="cursor: pointer;"
                 @endif
             >
-                {{ $record['title'] }}
+                @if($hasCardActionUrl)
+                    <a {{ $cardActionHref }} class="block">
+                        {{ $record['title'] }}
+                    </a>
+                @else
+                    {{ $record['title'] }}
+                @endif
             </h4>
 
             @if($hasActions)
@@ -42,14 +63,20 @@
         </div>
 
         <div class="px-3 pb-3"
-             @if($hasCardAction && $cardAction)
+             @if($hasCardAction && $cardAction && !$hasCardActionUrl)
                  wire:click="mountAction('{{ $cardAction }}', [], @js(['recordKey' => $record['id']]))"
              style="cursor: pointer;"
             @endif
         >
             {{-- Render card schema with compact spacing --}}
             @if(filled($record['schema']))
-                {{ $record['schema'] }}
+                @if($hasCardActionUrl)
+                    <a {{ $cardActionHref }} class="block">
+                        {{ $record['schema'] }}
+                    </a>
+                @else
+                    {{ $record['schema'] }}
+                @endif
             @endif
         </div>
     </div>

--- a/resources/views/livewire/card.blade.php
+++ b/resources/views/livewire/card.blade.php
@@ -10,16 +10,23 @@
     // A card action configured with ->url() must navigate like a native link instead
     // of mounting a modal, so middle-click, cmd-click and "copy link" keep working.
     //
-    // Only an explicitly configured url opts a card into link rendering. getUrl()
-    // also falls back to the livewire component's getDefaultActionUrl(), which
-    // Filament's resource pages implement for modal-less Create/Edit/View actions;
-    // honouring that here would silently turn existing boards into links. getUrl()
-    // still returns null when the action has a modal, and POST urls need a form
-    // rather than an anchor, so both fall through to the Livewire click handler.
+    // Three conditions keep an action on the Livewire click handler instead:
+    //
+    // - No explicit ->url(). getUrl() also falls back to the livewire component's
+    //   getDefaultActionUrl(), which Filament's resource pages implement for
+    //   modal-less Create/Edit/View actions; honouring that here would silently turn
+    //   existing boards into links. hasUrl() makes link rendering opt-in.
+    // - The action opens a modal. hasModal() only reports an explicit ->modal()
+    //   call, so it does not cover ->requiresConfirmation() or a custom modal
+    //   heading; shouldOpenModal() does. A whole card is a large accidental-click
+    //   target, so a configured confirmation step always wins over a url.
+    // - The url is posted to, which needs a form rather than an anchor.
     $cardActionInstance = $this->getBoard()->resolveCardAction($processedRecordActions);
-    $cardActionUrl = ($cardActionInstance?->hasUrl() && ! $cardActionInstance->shouldPostToUrl())
-        ? $cardActionInstance->getUrl()
-        : null;
+    $cardActionUrl = ($cardActionInstance?->hasUrl()
+        && ! $cardActionInstance->shouldOpenModal()
+        && ! $cardActionInstance->shouldPostToUrl())
+            ? $cardActionInstance->getUrl()
+            : null;
     $hasCardActionUrl = filled($cardActionUrl);
     $cardActionHref = $hasCardActionUrl
         ? \Filament\Support\generate_href_html(

--- a/src/Concerns/HasBoardActions.php
+++ b/src/Concerns/HasBoardActions.php
@@ -113,6 +113,42 @@ trait HasBoardActions
     }
 
     /**
+     * Find the configured card action among already-processed record actions.
+     *
+     * The record actions are passed in rather than rebuilt so the returned action
+     * keeps the record binding applied by getBoardRecordActions(), which is what
+     * makes per-record closures such as ->url(fn ($record) => ...) resolvable.
+     *
+     * @param  array<Action|ActionGroup>  $recordActions
+     */
+    public function resolveCardAction(array $recordActions): ?Action
+    {
+        $name = $this->getCardAction();
+
+        if (blank($name)) {
+            return null;
+        }
+
+        foreach ($recordActions as $action) {
+            if ($action instanceof ActionGroup) {
+                foreach ($action->getFlatActions() as $flatAction) {
+                    if ($flatAction->getName() === $name) {
+                        return $flatAction;
+                    }
+                }
+
+                continue;
+            }
+
+            if ($action->getName() === $name) {
+                return $action;
+            }
+        }
+
+        return null;
+    }
+
+    /**
      * Get registered card actions.
      */
     public function getRegisteredCardActions(): array

--- a/tests/Feature/CardActionUrlTest.php
+++ b/tests/Feature/CardActionUrlTest.php
@@ -6,8 +6,10 @@ use Livewire\Livewire;
 use Relaticle\Flowforge\Tests\Fixtures\Task;
 use Relaticle\Flowforge\Tests\Fixtures\TestBoard;
 use Relaticle\Flowforge\Tests\Fixtures\TestCardActionBoard;
+use Relaticle\Flowforge\Tests\Fixtures\TestCardActionConfirmBoard;
 use Relaticle\Flowforge\Tests\Fixtures\TestCardActionDefaultUrlBoard;
 use Relaticle\Flowforge\Tests\Fixtures\TestCardActionModalBoard;
+use Relaticle\Flowforge\Tests\Fixtures\TestCardActionModalHeadingBoard;
 use Relaticle\Flowforge\Tests\Fixtures\TestCardActionNewTabBoard;
 
 /**
@@ -65,6 +67,20 @@ test('card action inheriting only a default action url still mounts the action',
     $title = cardTitleHtml(Livewire::test(TestCardActionDefaultUrlBoard::class)->html());
 
     expect($title)->toContain("mountAction('run'")
+        ->and($title)->not->toContain('href=');
+});
+
+test('a confirmation on a url card action wins over the url', function () {
+    $title = cardTitleHtml(Livewire::test(TestCardActionConfirmBoard::class)->html());
+
+    expect($title)->toContain("mountAction('urlWithConfirmation'")
+        ->and($title)->not->toContain('href=');
+});
+
+test('a custom modal heading on a url card action wins over the url', function () {
+    $title = cardTitleHtml(Livewire::test(TestCardActionModalHeadingBoard::class)->html());
+
+    expect($title)->toContain("mountAction('urlWithModalHeading'")
         ->and($title)->not->toContain('href=');
 });
 

--- a/tests/Feature/CardActionUrlTest.php
+++ b/tests/Feature/CardActionUrlTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+use Livewire\Livewire;
+use Relaticle\Flowforge\Tests\Fixtures\Task;
+use Relaticle\Flowforge\Tests\Fixtures\TestBoard;
+use Relaticle\Flowforge\Tests\Fixtures\TestCardActionBoard;
+use Relaticle\Flowforge\Tests\Fixtures\TestCardActionModalBoard;
+use Relaticle\Flowforge\Tests\Fixtures\TestCardActionNewTabBoard;
+
+/**
+ * A card action configured with ->url() must render the card as a native link, so
+ * middle-click, cmd-click and "copy link address" keep working, instead of always
+ * mounting an action modal.
+ *
+ * @see https://github.com/relaticle/flowforge/issues/164
+ */
+beforeEach(function () {
+    $this->task = Task::factory()->create(['status' => 'todo', 'title' => 'Linked task']);
+});
+
+/**
+ * The card title is the click target the board wires up, so assertions have to look
+ * inside it: the actions dropdown renders its own anchor for the same action and
+ * would satisfy a whole-page assertion even when the card itself is not a link.
+ */
+function cardTitleHtml(string $html): string
+{
+    return str($html)
+        ->after('<h4 class="text-sm font-semibold')
+        ->before('</h4>')
+        ->toString();
+}
+
+test('card action with a url renders the card title as a link', function () {
+    $title = cardTitleHtml(Livewire::test(TestCardActionBoard::class)->html());
+
+    expect($title)->toContain('href="https://example.test/tasks/' . $this->task->getKey() . '"');
+});
+
+test('card action with a url does not mount an action on click', function () {
+    $html = Livewire::test(TestCardActionBoard::class)->html();
+
+    expect($html)->not->toContain("mountAction('view'");
+});
+
+test('card action honours openUrlInNewTab', function () {
+    $html = Livewire::test(TestCardActionNewTabBoard::class)->html();
+
+    expect(cardTitleHtml($html))
+        ->toContain('href="https://example.test/tasks/' . $this->task->getKey() . '" target="_blank"')
+        ->and($html)->not->toContain("mountAction('viewInNewTab'");
+});
+
+test('card action without a url still mounts the action', function () {
+    $title = cardTitleHtml(Livewire::test(TestCardActionModalBoard::class)->html());
+
+    expect($title)->toContain("mountAction('edit'")
+        ->and($title)->not->toContain('href=');
+});
+
+test('resolveCardAction finds the configured action among record actions', function () {
+    $board = Livewire::test(TestCardActionBoard::class)->instance()->getBoard();
+
+    $record = ['id' => $this->task->getKey(), 'model' => $this->task];
+
+    expect($board->resolveCardAction($board->getBoardRecordActions($record))?->getName())->toBe('view');
+});
+
+test('resolveCardAction returns null when no card action is configured', function () {
+    $board = Livewire::test(TestBoard::class)->instance()->getBoard();
+
+    expect($board->resolveCardAction([]))->toBeNull();
+});

--- a/tests/Feature/CardActionUrlTest.php
+++ b/tests/Feature/CardActionUrlTest.php
@@ -6,6 +6,7 @@ use Livewire\Livewire;
 use Relaticle\Flowforge\Tests\Fixtures\Task;
 use Relaticle\Flowforge\Tests\Fixtures\TestBoard;
 use Relaticle\Flowforge\Tests\Fixtures\TestCardActionBoard;
+use Relaticle\Flowforge\Tests\Fixtures\TestCardActionDefaultUrlBoard;
 use Relaticle\Flowforge\Tests\Fixtures\TestCardActionModalBoard;
 use Relaticle\Flowforge\Tests\Fixtures\TestCardActionNewTabBoard;
 
@@ -57,6 +58,13 @@ test('card action without a url still mounts the action', function () {
     $title = cardTitleHtml(Livewire::test(TestCardActionModalBoard::class)->html());
 
     expect($title)->toContain("mountAction('edit'")
+        ->and($title)->not->toContain('href=');
+});
+
+test('card action inheriting only a default action url still mounts the action', function () {
+    $title = cardTitleHtml(Livewire::test(TestCardActionDefaultUrlBoard::class)->html());
+
+    expect($title)->toContain("mountAction('run'")
         ->and($title)->not->toContain('href=');
 });
 

--- a/tests/Feature/CardActionUrlTest.php
+++ b/tests/Feature/CardActionUrlTest.php
@@ -63,25 +63,35 @@ test('card action without a url still mounts the action', function () {
         ->and($title)->not->toContain('href=');
 });
 
-test('card action inheriting only a default action url still mounts the action', function () {
+/**
+ * getUrl() falls back to the livewire component's getDefaultActionUrl(). Filament's
+ * table does the same, so a card follows it too rather than inventing its own rule.
+ */
+test('card action inheriting a default action url renders as a link', function () {
     $title = cardTitleHtml(Livewire::test(TestCardActionDefaultUrlBoard::class)->html());
 
-    expect($title)->toContain("mountAction('run'")
-        ->and($title)->not->toContain('href=');
+    expect($title)->toContain('href="https://example.test/default-action-url"')
+        ->and($title)->not->toContain("mountAction('run'");
 });
 
-test('a confirmation on a url card action wins over the url', function () {
+/**
+ * Filament decides this on the url alone. ListRecords::table() has recordAction() skip
+ * any action whose getUrl() is filled and recordUrl() pick it up instead, without
+ * consulting the action's modal state, so a url action that also declares a
+ * confirmation renders as a plain link in a table row too. A board card matches that.
+ */
+test('a url card action that also declares a confirmation renders as a link', function () {
     $title = cardTitleHtml(Livewire::test(TestCardActionConfirmBoard::class)->html());
 
-    expect($title)->toContain("mountAction('urlWithConfirmation'")
-        ->and($title)->not->toContain('href=');
+    expect($title)->toContain('href="https://example.test/tasks/' . $this->task->getKey() . '"')
+        ->and($title)->not->toContain("mountAction('urlWithConfirmation'");
 });
 
-test('a custom modal heading on a url card action wins over the url', function () {
+test('a url card action that also declares a modal heading renders as a link', function () {
     $title = cardTitleHtml(Livewire::test(TestCardActionModalHeadingBoard::class)->html());
 
-    expect($title)->toContain("mountAction('urlWithModalHeading'")
-        ->and($title)->not->toContain('href=');
+    expect($title)->toContain('href="https://example.test/tasks/' . $this->task->getKey() . '"')
+        ->and($title)->not->toContain("mountAction('urlWithModalHeading'");
 });
 
 test('resolveCardAction finds the configured action among record actions', function () {

--- a/tests/Fixtures/TestCardActionBoard.php
+++ b/tests/Fixtures/TestCardActionBoard.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\Flowforge\Tests\Fixtures;
+
+use Filament\Actions\Action;
+use Filament\Forms\Components\TextInput;
+use Illuminate\Database\Eloquent\Builder;
+use Relaticle\Flowforge\Board;
+use Relaticle\Flowforge\BoardPage;
+use Relaticle\Flowforge\Column;
+
+class TestCardActionBoard extends BoardPage
+{
+    public function getEloquentQuery(): Builder
+    {
+        return Task::query();
+    }
+
+    public function board(Board $board): Board
+    {
+        return $board
+            ->query($this->getEloquentQuery())
+            ->recordTitleAttribute('title')
+            ->columnIdentifier('status')
+            ->columns([
+                Column::make('todo')->label('To Do'),
+            ])
+            ->cardActions([
+                Action::make('view')
+                    ->url(fn (Task $record): string => "https://example.test/tasks/{$record->getKey()}"),
+                Action::make('viewInNewTab')
+                    ->url(fn (Task $record): string => "https://example.test/tasks/{$record->getKey()}")
+                    ->openUrlInNewTab(),
+                Action::make('edit')
+                    ->schema([
+                        TextInput::make('title'),
+                    ])
+                    ->action(function (): void {}),
+            ])
+            ->cardAction($this->cardActionName());
+    }
+
+    protected function cardActionName(): string
+    {
+        return 'view';
+    }
+}

--- a/tests/Fixtures/TestCardActionBoard.php
+++ b/tests/Fixtures/TestCardActionBoard.php
@@ -40,6 +40,14 @@ class TestCardActionBoard extends BoardPage
                     ->action(function (): void {}),
                 Action::make('run')
                     ->action(function (): void {}),
+                Action::make('urlWithConfirmation')
+                    ->url(fn (Task $record): string => "https://example.test/tasks/{$record->getKey()}")
+                    ->requiresConfirmation()
+                    ->action(function (): void {}),
+                Action::make('urlWithModalHeading')
+                    ->url(fn (Task $record): string => "https://example.test/tasks/{$record->getKey()}")
+                    ->modalHeading('Really?')
+                    ->action(function (): void {}),
             ])
             ->cardAction($this->cardActionName());
     }

--- a/tests/Fixtures/TestCardActionBoard.php
+++ b/tests/Fixtures/TestCardActionBoard.php
@@ -38,6 +38,8 @@ class TestCardActionBoard extends BoardPage
                         TextInput::make('title'),
                     ])
                     ->action(function (): void {}),
+                Action::make('run')
+                    ->action(function (): void {}),
             ])
             ->cardAction($this->cardActionName());
     }

--- a/tests/Fixtures/TestCardActionConfirmBoard.php
+++ b/tests/Fixtures/TestCardActionConfirmBoard.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\Flowforge\Tests\Fixtures;
+
+/**
+ * A card action carrying both ->url() and ->requiresConfirmation(). The whole card is a
+ * large accidental-click target, so the confirmation must win over the url.
+ */
+class TestCardActionConfirmBoard extends TestCardActionBoard
+{
+    protected function cardActionName(): string
+    {
+        return 'urlWithConfirmation';
+    }
+}

--- a/tests/Fixtures/TestCardActionDefaultUrlBoard.php
+++ b/tests/Fixtures/TestCardActionDefaultUrlBoard.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\Flowforge\Tests\Fixtures;
+
+use Filament\Actions\Action;
+
+/**
+ * A card action with no ->url() of its own, on a page whose getDefaultActionUrl()
+ * returns a url. Filament's resource pages do exactly this for modal-less
+ * Create/Edit/View actions, so the card must keep mounting the action rather than
+ * silently becoming a link.
+ */
+class TestCardActionDefaultUrlBoard extends TestCardActionBoard
+{
+    public function getDefaultActionUrl(Action $action): ?string
+    {
+        return 'https://example.test/default-action-url';
+    }
+
+    protected function cardActionName(): string
+    {
+        return 'run';
+    }
+}

--- a/tests/Fixtures/TestCardActionDefaultUrlBoard.php
+++ b/tests/Fixtures/TestCardActionDefaultUrlBoard.php
@@ -8,9 +8,10 @@ use Filament\Actions\Action;
 
 /**
  * A card action with no ->url() of its own, on a page whose getDefaultActionUrl()
- * returns a url. Filament's resource pages do exactly this for modal-less
- * Create/Edit/View actions, so the card must keep mounting the action rather than
- * silently becoming a link.
+ * returns a url. Filament's resource pages do this for modal-less Create/Edit/View
+ * actions when the resource has the matching page. Filament's own table honours that
+ * fallback (its recordUrl() closure reads getUrl(), which consults it), so the card
+ * does too.
  */
 class TestCardActionDefaultUrlBoard extends TestCardActionBoard
 {

--- a/tests/Fixtures/TestCardActionModalBoard.php
+++ b/tests/Fixtures/TestCardActionModalBoard.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\Flowforge\Tests\Fixtures;
+
+class TestCardActionModalBoard extends TestCardActionBoard
+{
+    protected function cardActionName(): string
+    {
+        return 'edit';
+    }
+}

--- a/tests/Fixtures/TestCardActionModalHeadingBoard.php
+++ b/tests/Fixtures/TestCardActionModalHeadingBoard.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\Flowforge\Tests\Fixtures;
+
+/**
+ * A card action carrying both ->url() and a custom modal heading. shouldOpenModal()
+ * reports true for it even though hasModal() does not, so the modal must win.
+ */
+class TestCardActionModalHeadingBoard extends TestCardActionBoard
+{
+    protected function cardActionName(): string
+    {
+        return 'urlWithModalHeading';
+    }
+}

--- a/tests/Fixtures/TestCardActionNewTabBoard.php
+++ b/tests/Fixtures/TestCardActionNewTabBoard.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\Flowforge\Tests\Fixtures;
+
+class TestCardActionNewTabBoard extends TestCardActionBoard
+{
+    protected function cardActionName(): string
+    {
+        return 'viewInNewTab';
+    }
+}

--- a/tests/Fixtures/TestPanelProvider.php
+++ b/tests/Fixtures/TestPanelProvider.php
@@ -29,6 +29,7 @@ class TestPanelProvider extends PanelProvider
             ->pages([
                 TestBoard::class,
                 TestCardActionBoard::class,
+                TestCardActionDefaultUrlBoard::class,
                 TestCardActionModalBoard::class,
                 TestCardActionNewTabBoard::class,
             ])

--- a/tests/Fixtures/TestPanelProvider.php
+++ b/tests/Fixtures/TestPanelProvider.php
@@ -29,7 +29,9 @@ class TestPanelProvider extends PanelProvider
             ->pages([
                 TestBoard::class,
                 TestCardActionBoard::class,
+                TestCardActionConfirmBoard::class,
                 TestCardActionDefaultUrlBoard::class,
+                TestCardActionModalHeadingBoard::class,
                 TestCardActionModalBoard::class,
                 TestCardActionNewTabBoard::class,
             ])

--- a/tests/Fixtures/TestPanelProvider.php
+++ b/tests/Fixtures/TestPanelProvider.php
@@ -28,6 +28,9 @@ class TestPanelProvider extends PanelProvider
             ->login()
             ->pages([
                 TestBoard::class,
+                TestCardActionBoard::class,
+                TestCardActionModalBoard::class,
+                TestCardActionNewTabBoard::class,
             ])
             ->resources([
                 TestResource::class,


### PR DESCRIPTION
Fixes #164.

## The bug

```php
->cardActions([
    Action::make('view')->url(fn (Task $record) => TaskResource::getUrl('view', ['record' => $record])),
])
->cardAction('view')
```

Clicking a card does nothing at all. Not a modal, not navigation. `->url()` is ignored.

## Root cause

`resources/views/livewire/card.blade.php` hardcoded the Livewire handler on both click targets (the title `<h4>` and the body `<div>`):

```blade
wire:click="mountAction('{{ $cardAction }}', [], @js(['recordKey' => $record['id']]))"
```

There was no url branch anywhere in the card render path. `Board::getCardAction()` returns only a **name**, so the resolved `Action` instance was never consulted and its url could never be read.

The contrast is visible on a single card in a single response. Same action, two renderings:

| Where | Markup |
|---|---|
| card title (`cardAction`) | `<h4 wire:click="mountAction('view', [], {recordKey: …})">` |
| actions dropdown (`cardActions`) | `<a href="https://…/tasks/01kxm3…">` |

The dropdown is correct because it goes through Filament's own action renderer. Mounting an action that has no modal and no callback is a no-op, so the click silently did nothing: `mountedActions` came back empty, the url never changed, and nothing was logged.

## The fix

`Board::resolveCardAction()` finds the configured card action among the record actions already processed for that card (flattening `ActionGroup`s). Taking them from `getBoardRecordActions()` rather than rebuilding matters: those clones carry the record binding, which is what makes `->url(fn ($record) => ...)` resolvable.

The blade then renders the title and body as anchors when the action has a url, built with `Filament\Support\generate_href_html()` and `hasNestedClickEventHandler: true`, the same helper and flag Filament's table rows use for `recordUrl`. SPA mode, prefetching, modifier-key handling and `->openUrlInNewTab()` therefore behave exactly as they do elsewhere in the panel.

## Following the framework's rule

The url on the action decides, with no check of its modal state. That is Filament's own rule, from `ListRecords::table()`:

- `recordAction()` iterates `view`/`edit` and skips any action whose `getUrl()` is filled
- `recordUrl()` iterates the same actions and skips any whose `getUrl()` is falsy

Neither closure consults `hasModal()` or `shouldOpenModal()`.

This PR originally added `hasUrl()` and `shouldOpenModal()` guards so that an action declaring both a url and a confirmation would keep showing the confirmation. That was wrong, and the last commit reverts it. Verified against a real Filament table in a Filament 5.4 app: with core's own `ListRecords` defaulting logic and an action carrying `->url()->requiresConfirmation()`, the table row renders `<a href>` and clicking it navigates with **no** confirmation. Keeping a stricter rule for boards would have meant one action behaving differently in a table row and on a card, which is worse than the config being self-contradictory in the first place.

So: the url wins in a board card, a table row, and the actions dropdown alike. An action should declare a url or a modal, not both. Only `->postToUrl()` actions stay on the Livewire click handler, because a POST needs a form rather than an anchor.

## Test plan

Nine tests in `tests/Feature/CardActionUrlTest.php`, across six `BoardPage` fixtures (url, new-tab url, modal, default-action-url page, url + confirmation, url + custom modal heading):

- card title renders `href` for a url card action
- no `mountAction('view'` handler is emitted anywhere for a url card action
- `->openUrlInNewTab()` produces `target="_blank"`
- a card action without a url still emits `mountAction('edit'` and no `href`
- a card action inheriting a default action url renders as a link
- a url card action that also declares a confirmation renders as a link
- a url card action that also declares a modal heading renders as a link
- `resolveCardAction()` finds the action, and returns `null` when none is configured

Assertions target the card title specifically, not the whole page: the actions dropdown renders its own anchor for the same action and would satisfy a page-wide assertion even with the bug present.

Also verified locally:

- `vendor/bin/pest`: 156 passed
- `vendor/bin/pint`: passed
- `vendor/bin/phpstan analyse`: 7 errors, in the same seven places as unmodified `4.x` (pre-existing, none in the changed code)
- Browser walk in a real Filament 5.4 app, covering the shipped board configuration and every new path: a plain url card action renders `<a href>` and navigates (previously the url never changed); `openUrlInNewTab` yields `target="_blank"`; a card action without a url still opens its modal; a bare `ViewAction` still opens its modal; browser Back after navigating restores the board. A screenshot of the linked board is indistinguishable from the board before the change, so the anchors introduce no visual difference.

Docs: added the url case to the `cardAction()` section of the API reference, including the "a url decides" precedence and its two consequences.

Worth squashing on merge: the four commits include one wrong turn and its revert.