### PR TITLE
chore(ci): pin actions to commit SHAs and add dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     labels:
       - "dependencies"
 
@@ -15,5 +17,7 @@ updates:
     directory: "/docs"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     labels:
       - "dependencies"

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -14,7 +14,7 @@ jobs:
 
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v3.1.0
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -25,19 +25,19 @@ jobs:
           echo "name=${BRANCH}" >> $GITHUB_OUTPUT
 
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ steps.branch.outputs.name }}
 
       - name: Update Changelog
-        uses: stefanzweifel/changelog-updater-action@v1
+        uses: stefanzweifel/changelog-updater-action@a938690fad7edf25368f37e43a1ed1b34303eb36 # v1.12.0
         with:
           latest-version: ${{ github.event.release.name }}
           release-notes: ${{ github.event.release.body }}
 
       - name: Open changelog PR
         id: cpr
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           base: ${{ steps.branch.outputs.name }}
           branch: chore/changelog-${{ github.event.release.tag_name }}

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -65,18 +65,18 @@ jobs:
           esac
 
       - name: Checkout source branch
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ steps.version.outputs.branch }}
 
       - name: Checkout gh-pages
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: gh-pages
           path: gh-pages
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
           cache: 'npm'

--- a/.github/workflows/pint.yml
+++ b/.github/workflows/pint.yml
@@ -14,14 +14,14 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.head_ref }}
 
       - name: Fix PHP code style issues
-        uses: aglipanci/laravel-pint-action@2.6
+        uses: aglipanci/laravel-pint-action@36de00d5f5a8a4e12d443e01671daa12a18f4c79 # 2.6
 
       - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@v7
+        uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7.2.0
         with:
           commit_message: Fix styling

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,35 @@ on:
     branches: [4.x]
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
+  actions-pinned:
+    name: Actions pinned to SHA
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Assert every third-party action is pinned to a full commit SHA
+        run: |
+          unpinned=$(grep -rhoE '^[[:space:]]*-?[[:space:]]*uses:[[:space:]]*[^[:space:]]+' .github/workflows \
+            | sed -E 's/.*uses:[[:space:]]*//' \
+            | grep -v '^\./' \
+            | grep -vE '@[0-9a-f]{40}$' \
+            | sort -u || true)
+
+          if [ -n "$unpinned" ]; then
+            echo "Third-party actions must be pinned to a full 40-character commit SHA."
+            echo "Unpinned references:"
+            echo "$unpinned" | sed 's/^/  /'
+            exit 1
+          fi
+
+          echo "All third-party action references are pinned to a full commit SHA."
+
   test:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -27,10 +55,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo


### PR DESCRIPTION
Closes the two failing Plumb security checks. Together they are the only thing keeping the package below 100.

| Check | Weight | Before | After |
|---|---|---|---|
| `security.actions-sha-pinned` | 8 | fail (0 / 12 pinned) | pass (13 / 13) |
| `security.dependency-update-cooldown` | 4 | fail (no cooldown) | pass (7 days) |

Security is scored 25 / 37 today, which is the 67.57 reported by Plumb. With both passing it is 37 / 37, taking the composite from **82.16 to 100**. Maintenance and Ecosystem are already 100.

## Pins

Every SHA was resolved through the GitHub API and cross-checked against the tag object it dereferences to. `actions/checkout` and `shivammathur/setup-php` match byte-for-byte what `bezhanSalleh/filament-shield` already ships.

| Action | SHA | Version |
|---|---|---|
| `actions/checkout` | `3d3c42e5aac5ba805825da76410c181273ba90b1` | v7.0.1 |
| `actions/setup-node` | `820762786026740c76f36085b0efc47a31fe5020` | v7.0.0 |
| `aglipanci/laravel-pint-action` | `36de00d5f5a8a4e12d443e01671daa12a18f4c79` | 2.6 |
| `dependabot/fetch-metadata` | `25dd0e34f4fe68f24cc83900b1fe3fe149efef98` | v3.1.0 |
| `peter-evans/create-pull-request` | `5f6978faf089d4d20b00c7766989d076bb2fc7f1` | v8.1.1 |
| `shivammathur/setup-php` | `f3e473d116dcccaddc5834248c87452386958240` | 2.37.2 |
| `stefanzweifel/changelog-updater-action` | `a938690fad7edf25368f37e43a1ed1b34303eb36` | v1.12.0 |
| `stefanzweifel/git-auto-commit-action` | `4a55954c782fc1ea30b9056cd3e7a2b40ca8887d` | v7.2.0 |

The trailing version comments are load-bearing. Dependabot reads them to know the current version, so `auto-merge.yml` keeps classifying updates as semver-minor/patch correctly after pinning.

`uses: ./.github/workflows/tests.yml` is left alone. Plumb exempts first-party refs, which are covered by branch protection.

## Cooldown

`default-days: 7` on both update entries. `github-actions` supports `default-days` only, not the `semver-*-days` variants. The threshold is at most 5 days (`laravel/framework` and `laravel/pint` pass at 5); 7 matches `filamentphp/filament` and `bezhanSalleh/filament-shield`.

No `composer` ecosystem was added. "Dependabot or Renovate configured" already passes, and a library with no committed lockfile would just get constraint-churn PRs.

## Regression guard

New `actions-pinned` job in `tests.yml` fails on any third-party `uses:` lacking a 40-hex SHA. Because `release.yml` calls `tests.yml` via `workflow_call`, releases are gated on it too.

`tests.yml` also gets `permissions: contents: read`. It was the only workflow with no `permissions:` block, so it was inheriting the repo default token scope. This is more restrictive than the caller in `release.yml`, which is allowed for reusable workflows.

## Verification

- All 6 workflows and `dependabot.yml` parse as YAML.
- 13 of 13 third-party refs match `@[0-9a-f]{40}`; 1 first-party ref exempt.
- Guard proven load-bearing: run against the pre-change tree it fails and lists exactly the 8 distinct unpinned refs Plumb flagged; against this branch it passes clean. Confirmed under two grep implementations.
- The `actions-pinned` and `test` jobs on this PR exercise the new pins live.

## Note on when the score moves

Plumb scores the **latest release tag**, not the branch head. Confirmed on packages where the two differ: `spatie/laravel-permission` is scored at tag `8.3.0` (`60e8ed5b`) while `main` is at `afd24018`; `livewire/livewire` at tag `v4.4.1` (`0c925c55`) while `4.x` is at `10b445a1`.

So merging this will not move the badge. It needs a `v4.1.1` tag, after which Plumb rescans on its 24h cadence.