### PR TITLE
chore(ci): adopt zizmor, fix its high findings, group dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     labels:
       - "dependencies"
 
@@ -15,5 +17,7 @@ updates:
     directory: "/docs"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     labels:
       - "dependencies"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,10 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    groups:
+      github-actions:
+        patterns:
+          - "*"
     labels:
       - "dependencies"
 
@@ -19,5 +23,9 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    groups:
+      npm:
+        patterns:
+          - "*"
     labels:
       - "dependencies"

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -14,7 +14,7 @@ jobs:
 
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v3.1.0
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,15 +1,19 @@
 name: Auto-Merge
 
-on: pull_request_target
+on: pull_request
 
 permissions:
-  pull-requests: write
-  contents: write
+  contents: read
 
 jobs:
   dependabot:
     runs-on: ubuntu-latest
-    if: ${{ github.actor == 'dependabot[bot]' }}
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
+
+    permissions:
+      pull-requests: write
+      contents: write
+
     steps:
 
       - name: Dependabot metadata

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -25,19 +25,19 @@ jobs:
           echo "name=${BRANCH}" >> $GITHUB_OUTPUT
 
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ steps.branch.outputs.name }}
 
       - name: Update Changelog
-        uses: stefanzweifel/changelog-updater-action@v1
+        uses: stefanzweifel/changelog-updater-action@a938690fad7edf25368f37e43a1ed1b34303eb36 # v1.12.0
         with:
           latest-version: ${{ github.event.release.name }}
           release-notes: ${{ github.event.release.body }}
 
       - name: Open changelog PR
         id: cpr
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           base: ${{ steps.branch.outputs.name }}
           branch: chore/changelog-${{ github.event.release.tag_name }}

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -15,14 +15,17 @@ jobs:
     steps:
       - name: Determine target branch
         id: branch
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+          REPO: ${{ github.repository }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
-          TAG="${{ github.event.release.tag_name }}"
           MAJOR=$(echo "$TAG" | sed -E 's/^v?([0-9]+)\..*/\1/')
           BRANCH="${MAJOR}.x"
-          if ! git ls-remote --exit-code --heads "https://github.com/${{ github.repository }}" "$BRANCH" > /dev/null 2>&1; then
-            BRANCH="${{ github.event.repository.default_branch }}"
+          if ! git ls-remote --exit-code --heads "https://github.com/$REPO" "$BRANCH" > /dev/null 2>&1; then
+            BRANCH="$DEFAULT_BRANCH"
           fi
-          echo "name=${BRANCH}" >> $GITHUB_OUTPUT
+          echo "name=${BRANCH}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -54,4 +57,5 @@ jobs:
         if: steps.cpr.outputs.pull-request-operation == 'created'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh pr merge --auto --squash "${{ steps.cpr.outputs.pull-request-number }}"
+          PR_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}
+        run: gh pr merge --auto --squash "$PR_NUMBER"

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -65,18 +65,18 @@ jobs:
           esac
 
       - name: Checkout source branch
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ steps.version.outputs.branch }}
 
       - name: Checkout gh-pages
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: gh-pages
           path: gh-pages
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
           cache: 'npm'

--- a/.github/workflows/pint.yml
+++ b/.github/workflows/pint.yml
@@ -14,14 +14,14 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.head_ref }}
 
       - name: Fix PHP code style issues
-        uses: aglipanci/laravel-pint-action@2.6
+        uses: aglipanci/laravel-pint-action@36de00d5f5a8a4e12d443e01671daa12a18f4c79 # 2.6
 
       - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@v7
+        uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7.2.0
         with:
           commit_message: Fix styling

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,16 +6,17 @@ on:
       - 'v*.*.*'
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   tests:
     uses: ./.github/workflows/tests.yml
-    secrets: inherit
 
   release:
     needs: tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Determine release flags

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Assert every third-party action is pinned to a full commit SHA
         run: |
@@ -56,6 +58,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup PHP
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,35 @@ on:
     branches: [4.x]
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
+  actions-pinned:
+    name: Actions pinned to SHA
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Assert every third-party action is pinned to a full commit SHA
+        run: |
+          unpinned=$(grep -rhoE '^[[:space:]]*-?[[:space:]]*uses:[[:space:]]*[^[:space:]]+' .github/workflows \
+            | sed -E 's/.*uses:[[:space:]]*//' \
+            | grep -v '^\./' \
+            | grep -vE '@[0-9a-f]{40}$' \
+            | sort -u || true)
+
+          if [ -n "$unpinned" ]; then
+            echo "Third-party actions must be pinned to a full 40-character commit SHA."
+            echo "Unpinned references:"
+            echo "$unpinned" | sed 's/^/  /'
+            exit 1
+          fi
+
+          echo "All third-party action references are pinned to a full commit SHA."
+
   test:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -27,10 +55,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,30 @@
+name: Zizmor
+
+on:
+  push:
+    paths:
+      - '.github/workflows/**'
+      - '.github/dependabot.yml'
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - '.github/dependabot.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Audit workflows
+        uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2


### PR DESCRIPTION
Builds on #168 and targets `4.x` directly, so the full test matrix and the pin guard actually run here (`tests.yml` only triggers on PRs into `4.x`, so a stacked base skipped them). Until #168 merges this PR shows both commits; once it does, the diff collapses to this commit alone. Merge #168 first.

#168 stops tag mutation. It says nothing about the rest of the workflow surface, so this adds the static analyser the ecosystem has standardised on and clears everything above low severity.

## zizmor findings

Ran `zizmor 1.29.0` locally against the `.github/` tree.

| | Before (#168) | After |
|---|---|---|
| High | 5 | **0** |
| Medium | 1 | **0** |
| Low | 6 | 4 |
| Informational | 5 | 4 |

| Rule | Where | Fix |
|---|---|---|
| `dangerous-triggers` | `auto-merge.yml` | `pull_request_target` to `pull_request` |
| `bot-conditions` | `auto-merge.yml` | `github.actor` to `github.event.pull_request.user.login` |
| `template-injection` x2 | `changelog.yml` | release tag and default branch passed through `env:` instead of interpolated into the `run` block |
| `excessive-permissions` | `release.yml` | `contents: write` moved from workflow level to the one job that needs it |
| `secrets-inherit` | `release.yml` | dropped `secrets: inherit`; `tests.yml` references no secrets |

## On the auto-merge trigger change

This is the one behavioural change, so it is worth being explicit. [GitHub's documented pattern](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions) for Dependabot auto-merge is `on: pull_request` with `permissions` elevated in the workflow, and the actor check reading `github.event.pull_request.user.login`.

That is both zizmor High findings at once. `pull_request_target` is flagged because it runs against the base with a privileged token; the actor check is flagged because `github.actor` is spoofable.

Dependabot-triggered `pull_request` runs get a read-only token by default, which is why the permissions are declared per job. `laravel/framework` runs this exact shape in production, so the path is proven, not theoretical.

## zizmor in CI

New `zizmor.yml`, copied from `filamentphp/filament`, path-filtered to `.github/**` and pinned to `zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2`.

Results go to the Security tab. This is deliberately advisory: the hard gate for pins stays the `actions-pinned` job in `tests.yml`, which `release.yml` calls via `workflow_call`, so **releases stay gated on pinning**. zizmor's lower-confidence heuristics should not block unrelated PRs.

## Dependabot grouping

Action and npm bumps now arrive as one PR each instead of one per dependency, matching `laravel/framework`. With the 7-day cooldown that means roughly one action-update PR a week. If a group contains a major bump, `update-type` reports `semver-major` and auto-merge correctly leaves it for review.

## What is intentionally left

Four `artipacked` (low) and four low-confidence `template-injection` (informational) findings. The checkouts named by `artipacked` are in `pint.yml`, `changelog.yml` and `deploy-docs.yml`, all of which push commits and need their credentials. `persist-credentials: false` was added only to the `tests.yml` checkouts, which do not.

## Verification

- All 7 workflows and `dependabot.yml` parse as YAML.
- `zizmor --min-severity medium .github/` reports `No findings to report.`
- Pin guard still passes: 15 of 15 third-party refs on a 40-char SHA, including the two new ones.
- `zizmorcore/zizmor-action@3dc1ecc9` re-resolved against its upstream repo.