### PR TITLE
fix(i18n): keep the German card label capitalised in the empty-column hint

### DIFF
--- a/resources/lang/de/flowforge.php
+++ b/resources/lang/de/flowforge.php
@@ -2,7 +2,7 @@
 
 return [
     'loading_more_cards' => 'Lade mehr Karten...',
-    'no_cards_in_column' => 'Keine :cardLabel in dieser Spalte',
+    'no_cards_in_column' => 'Keine :CardLabel in dieser Spalte',
     'cards_count' => '{0} :cards|{1} :card|[2,*] :cards',
     'card_label' => 'Datensatz',
     'plural_card_label' => 'Datensätze',

--- a/tests/Unit/TranslationTest.php
+++ b/tests/Unit/TranslationTest.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Blade;
+
+test('the German empty column hint keeps the card label capitalised', function () {
+    app()->setLocale('de');
+
+    $html = Blade::render('<x-flowforge::empty-column :pluralCardLabel="$label" />', [
+        'label' => __('flowforge::flowforge.plural_card_label'),
+    ]);
+
+    expect($html)->toContain('Keine Datensätze in dieser Spalte');
+});


### PR DESCRIPTION
### Problem

`empty-column.blade.php` lowercases the plural card label before interpolating it:

```blade
{{ __('flowforge::flowforge.no_cards_in_column', ['cardLabel' => strtolower($pluralCardLabel)]) }}
```

That reads naturally in English (*"No records in this column"*), but German capitalises every noun, so a German board shows:

> Keine **d**atensätze in dieser Spalte

### Fix

Use Laravel's capitalising placeholder (`:CardLabel`) in the German line, so the label is restored to *Datensätze* after the view lowercased it:

```php
'no_cards_in_column' => 'Keine :CardLabel in dieser Spalte',
```

One line, German only — `en`, `es` and `nl` are untouched, and the view needs no change.

### Test

`tests/Unit/TranslationTest.php` renders the component in German and asserts the capitalised hint. It fails on `4.x` without the lang change and passes with it; `vendor/bin/pest tests/Unit` stays green (43 passed).