### PR TITLE
chore: update compatible Composer and npm dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,18 +33,18 @@
         "filament/filament": "Required for BoardPage, BoardResourcePage, and FlowforgePlugin panel integration (^5.0)"
     },
     "require-dev": {
-        "filament/filament": "^5.0",
-        "larastan/larastan": "^3.0",
-        "laravel/pint": "^1.0",
-        "nunomaduro/collision": "^8.0",
-        "orchestra/testbench": "^10.11|^11.0",
-        "pestphp/pest": "^4.0|^5.0",
-        "pestphp/pest-plugin-arch": "^4.0|^5.0",
-        "pestphp/pest-plugin-laravel": "^4.0|^5.0",
-        "phpstan/extension-installer": "^1.4",
-        "phpstan/phpstan-deprecation-rules": "^2.0",
-        "phpstan/phpstan-phpunit": "^2.0",
-        "spatie/laravel-ray": "^1.26"
+        "filament/filament": "^5.7.8",
+        "larastan/larastan": "^3.11",
+        "laravel/pint": "^1.30.5",
+        "nunomaduro/collision": "^8.9.5",
+        "orchestra/testbench": "^10.11|^11.2",
+        "pestphp/pest": "^4.7.8|^5.1.3",
+        "pestphp/pest-plugin-arch": "^4.0.2|^5.0",
+        "pestphp/pest-plugin-laravel": "^4.1|^5.0.1",
+        "phpstan/extension-installer": "^1.4.3",
+        "phpstan/phpstan-deprecation-rules": "^2.0.5",
+        "phpstan/phpstan-phpunit": "^2.0.18",
+        "spatie/laravel-ray": "^1.43.9"
     },
     "autoload": {
         "psr-4": {

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -11,7 +11,7 @@
                 "@nuxt/ui": "^4.11.0",
                 "@unhead/vue": "^3.4.0",
                 "better-sqlite3": "^12.11.1",
-                "docus": "^5.12.3",
+                "docus": "^5.13.0",
                 "nuxt": "^4.5.2",
                 "typescript": "^7.0.2"
             },
@@ -23,90 +23,101 @@
             }
         },
         "node_modules/@ai-sdk/gateway": {
-            "version": "3.0.176",
-            "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.176.tgz",
-            "integrity": "sha512-/ul6GQ+nh5E4tAqOgMBQA69vQ7x0CAq12fcA0NKhcGHYYpX+L8kIHvFDSffAhDm78i1bRMZumnJyQZwVwNu2jg==",
+            "version": "4.0.75",
+            "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-4.0.75.tgz",
+            "integrity": "sha512-HOnhw3oXtBnboBF7kAKipjToCN6+5w6EuukiUKiULcxBitS+vbHRRv9IUBcq+Z1wkXcJjfywKrt5r++I6OYyXg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@ai-sdk/provider": "3.0.15",
-                "@ai-sdk/provider-utils": "4.0.46",
+                "@ai-sdk/provider": "4.0.10",
+                "@ai-sdk/provider-utils": "5.0.36",
                 "@vercel/oidc": "3.2.0"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=22"
             },
             "peerDependencies": {
                 "zod": "^3.25.76 || ^4.1.8"
             }
         },
         "node_modules/@ai-sdk/mcp": {
-            "version": "1.0.71",
-            "resolved": "https://registry.npmjs.org/@ai-sdk/mcp/-/mcp-1.0.71.tgz",
-            "integrity": "sha512-woKUwm/yiqxEC+E863tqAjEpiyWCERmy//k9pdNYP8Ta6+PF6Ge2X6p99e72BdBovB+/McUWgbJ4+Fiht+41WQ==",
+            "version": "2.0.45",
+            "resolved": "https://registry.npmjs.org/@ai-sdk/mcp/-/mcp-2.0.45.tgz",
+            "integrity": "sha512-ROukI/LfoPHf5F4gi1GKQebK5658fR1EG3kt0P0vzrfSy1FAGQ5FyKr9j2lbkXAV9X3kfpf9LJdif7w67XDtgw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@ai-sdk/provider": "3.0.15",
-                "@ai-sdk/provider-utils": "4.0.46",
-                "pkce-challenge": "^5.0.0"
+                "@ai-sdk/provider": "4.0.10",
+                "@ai-sdk/provider-utils": "5.0.36",
+                "cross-spawn": "^7.0.6",
+                "pkce-challenge": "^5.0.1"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=22"
             },
             "peerDependencies": {
                 "zod": "^3.25.76 || ^4.1.8"
             }
         },
         "node_modules/@ai-sdk/provider": {
-            "version": "3.0.15",
-            "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.15.tgz",
-            "integrity": "sha512-XeZW1CcDF2GMbH4wejW6xBRI2QCOgnkVYUnxoeDadB1mf85riL2bMUeDoh+6gJ/r4mjNfzUPW8OjLjvwTP0u1Q==",
+            "version": "4.0.10",
+            "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-4.0.10.tgz",
+            "integrity": "sha512-fX2ENAc7iDpZ+Wp4+Rk06Usn/Ys7dI9uAkGv0jlF6XVrW13NkRWx5Ou+U6lIM2E1fTLkCs16GGrUAaVvroag7A==",
             "license": "Apache-2.0",
             "dependencies": {
                 "json-schema": "^0.4.0"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=22"
             }
         },
         "node_modules/@ai-sdk/provider-utils": {
-            "version": "4.0.46",
-            "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.46.tgz",
-            "integrity": "sha512-tEtld97plCFiYevsJuOkGkeuhQndeMWFBVrJS4AjnbD5AqrNSXRCe0p+BZ3Cju/sxDeeZ9ym3q9YUV8fASA7aQ==",
+            "version": "5.0.36",
+            "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-5.0.36.tgz",
+            "integrity": "sha512-MFXBn6XDyf37PNQAge/HTatPJE8Vmg/g/w4WPtjSV53jq8FKAzoaN5+43hsdQa9bqgN+/13jxug9ChvsG+godQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@ai-sdk/provider": "3.0.15",
+                "@ai-sdk/provider": "4.0.10",
                 "@standard-schema/spec": "^1.1.0",
+                "@workflow/serde": "4.1.0",
                 "eventsource-parser": "^3.0.8",
-                "undici": "^6.28.0"
+                "undici": "^7.29.0"
             },
             "engines": {
-                "node": ">=18.17"
+                "node": ">=22"
             },
             "peerDependencies": {
                 "zod": "^3.25.76 || ^4.1.8"
             }
         },
+        "node_modules/@ai-sdk/provider-utils/node_modules/undici": {
+            "version": "7.29.1",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.1.tgz",
+            "integrity": "sha512-RYONW2MeafgYlkVOKYKkA/Ag7BmXqgIWCa8t1m0JcxrQg9pI9lEqRhAOruOBCbAohOa/gkCF+iPi9hrgvTzu6Q==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.18.1"
+            }
+        },
         "node_modules/@ai-sdk/vue": {
-            "version": "3.0.258",
-            "resolved": "https://registry.npmjs.org/@ai-sdk/vue/-/vue-3.0.258.tgz",
-            "integrity": "sha512-8sTnzai/Qahgm276blh1EWV6tL4G+FFYpp4vM4hHZl4wLD3Z5q5CV62o3moxi5NkfQr+NNEl6OUyEZ11SmoInQ==",
+            "version": "4.0.93",
+            "resolved": "https://registry.npmjs.org/@ai-sdk/vue/-/vue-4.0.93.tgz",
+            "integrity": "sha512-Q3muTnEAMHO3PnA+7A2BgldEURTo6hguPknoMgx3/OjlbsPt7vAl8zm9j4LDyxaBblnawuVTeI05MRKT6F/yrg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@ai-sdk/provider-utils": "4.0.46",
-                "ai": "6.0.258",
-                "swrv": "^1.0.4"
+                "@ai-sdk/provider-utils": "5.0.36",
+                "ai": "7.0.93",
+                "swrv": "^1.2.0"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=22"
             },
             "peerDependencies": {
                 "vue": "^3.3.4"
             }
         },
         "node_modules/@alloc/quick-lru": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
-            "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.3.0.tgz",
+            "integrity": "sha512-U4+70Pc5ZS9osnCBCE5Jha/ciHM+Yp+CNMNC/7HvYbNRk1Ldd+f7qO65W5qfhu/TCv+/ozljlXXe9Nj8419DMA==",
             "license": "MIT",
             "engines": {
                 "node": ">=10"
@@ -116,13 +127,13 @@
             }
         },
         "node_modules/@antfu/install-pkg": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-1.1.0.tgz",
-            "integrity": "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-2.0.1.tgz",
+            "integrity": "sha512-iCKVQcIC0e3oDxEfs3SHQGW+ovhBMZmS1TE+bTk50rVyMCBmCfClv7Qi3HQKlumYwvjb/iIMeWCW2i67q6kFfQ==",
             "license": "MIT",
             "dependencies": {
-                "package-manager-detector": "^1.3.0",
-                "tinyexec": "^1.0.1"
+                "package-manager-detector": "^1.7.0",
+                "tinyexec": "^1.2.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/antfu"
@@ -574,6 +585,30 @@
                 }
             }
         },
+        "node_modules/@cacheable/memory": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@cacheable/memory/-/memory-2.2.0.tgz",
+            "integrity": "sha512-CTLKqLItRCEixEAewD3/j9DB3/o96gpTPD4eJ1v+DGOlxZRZncRQkGYqqnAGCscYd6RNeXfGeiuCphsPtqyIfQ==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@cacheable/utils": "^2.5.0",
+                "@keyv/bigmap": "^1.3.1",
+                "hookified": "^1.15.1",
+                "keyv": "^5.6.0"
+            }
+        },
+        "node_modules/@cacheable/utils": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.5.0.tgz",
+            "integrity": "sha512-buipgOVDkkPXNR5+xBpDw7Zk2n1EvU7qBJCNUcL7rhQ//kfpOXPAvQ511Os0vpLYJ1pZnvudNytkQt2hst3wqA==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "hashery": "^1.5.1",
+                "keyv": "^5.6.0"
+            }
+        },
         "node_modules/@capsizecss/unpack": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/@capsizecss/unpack/-/unpack-4.0.1.tgz",
@@ -624,22 +659,22 @@
             }
         },
         "node_modules/@colordx/core": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/@colordx/core/-/core-5.5.0.tgz",
-            "integrity": "sha512-3PxTH8itZzltK0U9jTwVVnjLXvnDYuq3m+QXsHkENxWiPRh4WaoLcs1SQjqgZ55kS+QyirpH5BVwzP2gMVG6EQ==",
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@colordx/core/-/core-5.8.0.tgz",
+            "integrity": "sha512-cG0QJAO6VkaRUlIb0zOzX9gfJgs1pjoOL9gZ/PK1kfvBs0GCkADu5oQh6gPxXgQnZ3gV575h+lQRC0NlMDTclA==",
             "license": "MIT"
         },
         "node_modules/@comark/vue": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/@comark/vue/-/vue-0.4.0.tgz",
-            "integrity": "sha512-1o4BBBzVIcxCsPOfWUzcYqdnSSI+bCyldxzlrbATc5U+s40Hm+ls7UppYAHPyOqUQPpMZy2vbvD4ESe+PD5lgg==",
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/@comark/vue/-/vue-0.6.2.tgz",
+            "integrity": "sha512-ToRyzz4I96DjXtDgYOC1WnNWt0W6YgOcazuT8rVRMJRR86NXBLATnIWb3hdMM0/8lMaDz+DmlcpX5EN1hqsG0Q==",
             "dependencies": {
-                "comark": "^0.4.0"
+                "comark": "0.6.2"
             },
             "peerDependencies": {
                 "beautiful-mermaid": "^1.1.3",
-                "katex": "^0.16.45",
-                "shiki": "^4.0.0",
+                "katex": "^0.17.0",
+                "shiki": "^4.3.1",
                 "vue": "^3.5.0"
             },
             "peerDependenciesMeta": {
@@ -655,9 +690,9 @@
             }
         },
         "node_modules/@dxup/nuxt": {
-            "version": "0.5.8",
-            "resolved": "https://registry.npmjs.org/@dxup/nuxt/-/nuxt-0.5.8.tgz",
-            "integrity": "sha512-IuKNesqRKXNYFqLtDHZlV2GBNY+iyb6lc64zVxLXssXgb+O1bfirRbeuzscVNgDrRtAPs/htb3dNF4aCwRctIw==",
+            "version": "0.5.10",
+            "resolved": "https://registry.npmjs.org/@dxup/nuxt/-/nuxt-0.5.10.tgz",
+            "integrity": "sha512-54Vehb7LmR7qYpC6KFwjDTSm6CB1CayBu+JXdHrPLrIjjr5xAgb43jvgOU+mnB+tsRh414fSsEy0QjBMKILQ8g==",
             "license": "MIT",
             "dependencies": {
                 "@dxup/unimport": "^0.1.2",
@@ -665,7 +700,7 @@
                 "@vue/compiler-dom": "^3.5.41",
                 "chokidar": "^5.0.0",
                 "knitwork": "^1.3.0",
-                "magic-string": "^1.2.0",
+                "magic-string": "^1.2.2",
                 "pathe": "^2.0.3",
                 "tinyglobby": "^0.2.17",
                 "unplugin": "^3.3.0"
@@ -1204,9 +1239,9 @@
             }
         },
         "node_modules/@eslint/plugin-kit": {
-            "version": "0.7.2",
-            "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
-            "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
+            "version": "0.7.3",
+            "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.3.tgz",
+            "integrity": "sha512-IkO+/KEUvwbVpiURZg+P7zF74z5Jxe0UgJxVni+RtoHQ6IZieXaO02kmadomap/q+l6bc/jdPGGqTjhuZnuz1Q==",
             "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
@@ -1364,36 +1399,36 @@
             }
         },
         "node_modules/@iconify-json/lucide": {
-            "version": "1.2.124",
-            "resolved": "https://registry.npmjs.org/@iconify-json/lucide/-/lucide-1.2.124.tgz",
-            "integrity": "sha512-mO6JyBVNER7uXEkW2bXiN9Rrm6w91IXxwnNmIMbu2KZX0ZPcVZH1xDUTw94pryxESUIpBhinkOUIZIav+TA9ng==",
+            "version": "1.2.129",
+            "resolved": "https://registry.npmjs.org/@iconify-json/lucide/-/lucide-1.2.129.tgz",
+            "integrity": "sha512-pa0ufllJOXTDIH2BxE/BtWQEf/x46/lINDWcmncICV1/52veZ7KSBzQaVh9xDpmjDs8QN4j2Ex/LWlSSveL3yw==",
             "license": "ISC",
             "dependencies": {
                 "@iconify/types": "*"
             }
         },
         "node_modules/@iconify-json/simple-icons": {
-            "version": "1.2.93",
-            "resolved": "https://registry.npmjs.org/@iconify-json/simple-icons/-/simple-icons-1.2.93.tgz",
-            "integrity": "sha512-/XhANjfGYOuqvSR3TmUnkQkINvQ4GVjVuukvymRbxtVFBvIq/yiXJqCDycKcQPT401OYT9H2vIY6ihAlz1QIAw==",
+            "version": "1.2.94",
+            "resolved": "https://registry.npmjs.org/@iconify-json/simple-icons/-/simple-icons-1.2.94.tgz",
+            "integrity": "sha512-l8UWzVxKaqZd9ABsE/M/9p6NyGkQnmCnOoZyhQmjlXCtY5PuL2rcWxOFk2l9pk7ux3ERMPkTLE4jl6kQpTkwxA==",
             "license": "CC0-1.0",
             "dependencies": {
                 "@iconify/types": "*"
             }
         },
         "node_modules/@iconify-json/vscode-icons": {
-            "version": "1.2.74",
-            "resolved": "https://registry.npmjs.org/@iconify-json/vscode-icons/-/vscode-icons-1.2.74.tgz",
-            "integrity": "sha512-ZVf1IM5sOvvY+0Gc6jtuD5okkd51mJe/BoVMhWJCu1WqZLSF6XgbSguxUOyuBmMjJXNPSw1OBvPwEVq1bXfiTw==",
+            "version": "1.2.76",
+            "resolved": "https://registry.npmjs.org/@iconify-json/vscode-icons/-/vscode-icons-1.2.76.tgz",
+            "integrity": "sha512-gSu20bZiegbMFLSPHHtmliUJoOPhovTT77RNkMfr6u9ns5uC2bVZ4K5T7wUlywRAzQk4qgG7t4AULaucSsta4w==",
             "license": "MIT",
             "dependencies": {
                 "@iconify/types": "*"
             }
         },
         "node_modules/@iconify/collections": {
-            "version": "1.0.729",
-            "resolved": "https://registry.npmjs.org/@iconify/collections/-/collections-1.0.729.tgz",
-            "integrity": "sha512-eGNUVgmRnYddRutbrE/raedbnqVEdTQv4R9L/nmEHNCoEKQnTj4obNWOmH/38+J25F2svv8AQiZBNRGwPYtoyQ==",
+            "version": "1.0.733",
+            "resolved": "https://registry.npmjs.org/@iconify/collections/-/collections-1.0.733.tgz",
+            "integrity": "sha512-ckW+JM8b+Pt07fg5bpNbI05m6a8m7MptMb+QbRnsaNvqefvhJsqHzw1ZLtOCd2gxieDIERuIQBokZ/Ssf96sew==",
             "license": "MIT",
             "dependencies": {
                 "@iconify/types": "*"
@@ -1406,12 +1441,12 @@
             "license": "MIT"
         },
         "node_modules/@iconify/utils": {
-            "version": "3.1.4",
-            "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.4.tgz",
-            "integrity": "sha512-b1S7B1k9ohZ+iNTi2ATxbRYG9fTrJmUT0rc46bvVnNxqNRGW7dyo/vRREwyniI5IRN2RSJHDcm+s3BjWrSAjHw==",
+            "version": "3.1.6",
+            "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.6.tgz",
+            "integrity": "sha512-9n9RQsMcfgXa8aXrHIMGAFwlm+YpY/HxRqBgCQzeMMimdOBA7hvfqDdWE/Zg5sr5SinaY78zYTPkSfG7Sy+moA==",
             "license": "MIT",
             "dependencies": {
-                "@antfu/install-pkg": "^1.1.0",
+                "@antfu/install-pkg": "^2.0.1",
                 "@iconify/types": "^2.0.0",
                 "import-meta-resolve": "^4.2.0"
             }
@@ -1442,9 +1477,9 @@
             }
         },
         "node_modules/@img/sharp-darwin-arm64": {
-            "version": "0.35.3",
-            "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.3.tgz",
-            "integrity": "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==",
+            "version": "0.35.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.4.tgz",
+            "integrity": "sha512-Uhfl4V4lhP2nbUVF9+hyH1+luj86f1gUFeo8ALYxFoULoU+G87D43BfeMP8XHsk9boxAnCY/bf2EHwhA7MuGsA==",
             "cpu": [
                 "arm64"
             ],
@@ -1460,13 +1495,13 @@
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-darwin-arm64": "1.3.2"
+                "@img/sharp-libvips-darwin-arm64": "1.3.3"
             }
         },
         "node_modules/@img/sharp-darwin-x64": {
-            "version": "0.35.3",
-            "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz",
-            "integrity": "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==",
+            "version": "0.35.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.4.tgz",
+            "integrity": "sha512-hWniXY3bG5qKpkKrAwPe4y+VTPmf086YQAnkxWh7uA1YrlRouWGa0M0Mxj3ZjnXFkv7/TD1bTy9lGUK26vRvWw==",
             "cpu": [
                 "x64"
             ],
@@ -1482,20 +1517,20 @@
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-darwin-x64": "1.3.2"
+                "@img/sharp-libvips-darwin-x64": "1.3.3"
             }
         },
         "node_modules/@img/sharp-freebsd-wasm32": {
-            "version": "0.35.3",
-            "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
-            "integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
+            "version": "0.35.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.4.tgz",
+            "integrity": "sha512-lIsKw/BU+kjB4eZjxrYrZmwOJYi3Ajrv66iAlBmUPyKc3HpnloevB1g3wxGD9P/5BbQ1brBGl65VRRrCvQDEqA==",
             "license": "Apache-2.0",
             "optional": true,
             "os": [
                 "freebsd"
             ],
             "dependencies": {
-                "@img/sharp-wasm32": "0.35.3"
+                "@img/sharp-wasm32": "0.35.4"
             },
             "engines": {
                 "node": ">=20.9.0"
@@ -1505,9 +1540,9 @@
             }
         },
         "node_modules/@img/sharp-libvips-darwin-arm64": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.2.tgz",
-            "integrity": "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==",
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.3.tgz",
+            "integrity": "sha512-suTBPTDGrI9WodccaDdwZItTSaBYASlBk1NSfElSHrUfzu3szG6lvIF58+WiFvnfzuK8ZBFS5zE00PxqxnRiPg==",
             "cpu": [
                 "arm64"
             ],
@@ -1521,9 +1556,9 @@
             }
         },
         "node_modules/@img/sharp-libvips-darwin-x64": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz",
-            "integrity": "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==",
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.3.tgz",
+            "integrity": "sha512-FVJZ5mITMobmXIz/hPDTw0EintTW5H3WfrxwLqEqjiIihlu+hVRyGrFQ60xl0Lxn7Bt3zdpevPaQi0HEzqz9fw==",
             "cpu": [
                 "x64"
             ],
@@ -1537,9 +1572,9 @@
             }
         },
         "node_modules/@img/sharp-libvips-linux-arm": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz",
-            "integrity": "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==",
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.3.tgz",
+            "integrity": "sha512-3rbU4vqXXc3hY/OiXdl52xZvT0F1yEngWfvqudtPJg/KkyiaQw2DRsFrNzpmLvfavbwOq3qXn36GP8obHRULQA==",
             "cpu": [
                 "arm"
             ],
@@ -1556,9 +1591,9 @@
             }
         },
         "node_modules/@img/sharp-libvips-linux-arm64": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz",
-            "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.3.tgz",
+            "integrity": "sha512-0DaL0A6Xu6sQSQFwe4iVCrKWU2cCTItnRsYsCdxAMm9NF6twAA9BKnoqy4hqz4+azQ0JHuA26qiUKsf1XJ/v5A==",
             "cpu": [
                 "arm64"
             ],
@@ -1575,9 +1610,9 @@
             }
         },
         "node_modules/@img/sharp-libvips-linux-ppc64": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz",
-            "integrity": "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==",
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.3.tgz",
+            "integrity": "sha512-cdn1OvUBwsXhbC0zSzJnNzf5MZ/mTrobawDvNXBTxe8VtqKAm0sRuEY2Evzovb/w9JMk4TvRxqt1mekSuJz64w==",
             "cpu": [
                 "ppc64"
             ],
@@ -1594,9 +1629,9 @@
             }
         },
         "node_modules/@img/sharp-libvips-linux-riscv64": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz",
-            "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.3.tgz",
+            "integrity": "sha512-HjPVx7yKz+0lqdhDlTw1tt90wamBoxhiXpvl1XZpJLiHH4RCJ5yDTqH+VlYPv2fwFs89JFw4c1IexYOcQUi4IQ==",
             "cpu": [
                 "riscv64"
             ],
@@ -1613,9 +1648,9 @@
             }
         },
         "node_modules/@img/sharp-libvips-linux-s390x": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz",
-            "integrity": "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==",
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.3.tgz",
+            "integrity": "sha512-neWLh+3yCNThxnfy3c4BbVBeGgt9aftno+XbT56iK28RgeDs3UOFWviLWlUu0bArYVYJaFDK+RRohbicUNCm8Q==",
             "cpu": [
                 "s390x"
             ],
@@ -1632,9 +1667,9 @@
             }
         },
         "node_modules/@img/sharp-libvips-linux-x64": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz",
-            "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.3.tgz",
+            "integrity": "sha512-4vKmvAst9nrowcqquKFAyZJUDolUaIp8uRiN0mWFguJ1IplC9/pitXtlnnlU4aa/eJw3J7i67V+pwUL+wZGdsA==",
             "cpu": [
                 "x64"
             ],
@@ -1651,9 +1686,9 @@
             }
         },
         "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz",
-            "integrity": "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==",
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.3.tgz",
+            "integrity": "sha512-Y9kQaLMuNoB0bPYOOdcZMaseNrFpPodIWWMrx+CZyydf2xn68j9WYc6sWWRrDwNkzCQjKYfc68L7jKjGlHMibw==",
             "cpu": [
                 "arm64"
             ],
@@ -1670,9 +1705,9 @@
             }
         },
         "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz",
-            "integrity": "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==",
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.3.tgz",
+            "integrity": "sha512-fj8Mv0HHfD1Rr+4I68+3agJynxDWtBFgicTbSOb9Bke6pIwzGcJ+RX/yHjmiEGFMCavY/dxvem7MyNaJF+wDiw==",
             "cpu": [
                 "x64"
             ],
@@ -1689,9 +1724,9 @@
             }
         },
         "node_modules/@img/sharp-linux-arm": {
-            "version": "0.35.3",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz",
-            "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
+            "version": "0.35.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.4.tgz",
+            "integrity": "sha512-7OAS8gI0EReKGVN2HssHlM6umJgxF5VI3xN0p9FA91p/YO+ou5hiNghLdZ5BEHztwaaK5+bLKRf8x/o2L2nk9A==",
             "cpu": [
                 "arm"
             ],
@@ -1710,13 +1745,13 @@
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-linux-arm": "1.3.2"
+                "@img/sharp-libvips-linux-arm": "1.3.3"
             }
         },
         "node_modules/@img/sharp-linux-arm64": {
-            "version": "0.35.3",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz",
-            "integrity": "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==",
+            "version": "0.35.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.4.tgz",
+            "integrity": "sha512-De4jpEnAU8Hd5oT0j1G3uL4ZvTuipVMn7YC6vPaJhy6/7EwEae0SVAoBrUMYQbkLGDm85taVWwuPc1a44LTzCQ==",
             "cpu": [
                 "arm64"
             ],
@@ -1735,13 +1770,13 @@
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-linux-arm64": "1.3.2"
+                "@img/sharp-libvips-linux-arm64": "1.3.3"
             }
         },
         "node_modules/@img/sharp-linux-ppc64": {
-            "version": "0.35.3",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz",
-            "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
+            "version": "0.35.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.4.tgz",
+            "integrity": "sha512-2oYZJeIl4kCcMGk4ouZVjnkCtFrpQFlNEtJ6GbxzhHQchwH0NH/qEb9ykmOl29dqwMq+JhFdZn+1ak2FKhI9fQ==",
             "cpu": [
                 "ppc64"
             ],
@@ -1760,13 +1795,13 @@
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-linux-ppc64": "1.3.2"
+                "@img/sharp-libvips-linux-ppc64": "1.3.3"
             }
         },
         "node_modules/@img/sharp-linux-riscv64": {
-            "version": "0.35.3",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz",
-            "integrity": "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==",
+            "version": "0.35.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.4.tgz",
+            "integrity": "sha512-cPbNChoRURAWdebDIHSenxRpgEdy7JkPydSnUxRm9VvKD7m0/xVaR/8Fzlu81pk5nHEvHH87UZUA7cTtwnbJSA==",
             "cpu": [
                 "riscv64"
             ],
@@ -1785,13 +1820,13 @@
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-linux-riscv64": "1.3.2"
+                "@img/sharp-libvips-linux-riscv64": "1.3.3"
             }
         },
         "node_modules/@img/sharp-linux-s390x": {
-            "version": "0.35.3",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz",
-            "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
+            "version": "0.35.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.4.tgz",
+            "integrity": "sha512-RY0JFY8Fd6RonCBtHz+DvadaPkXDSI1AUn6yWL9TipqkZ1vY8w8evqdgyDFnkm4/K1ve1TvZiaePP5oSd4+WVQ==",
             "cpu": [
                 "s390x"
             ],
@@ -1810,13 +1845,13 @@
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-linux-s390x": "1.3.2"
+                "@img/sharp-libvips-linux-s390x": "1.3.3"
             }
         },
         "node_modules/@img/sharp-linux-x64": {
-            "version": "0.35.3",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz",
-            "integrity": "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==",
+            "version": "0.35.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.4.tgz",
+            "integrity": "sha512-9qvvEAuk8k89TfWUoX2htWjbAMX8p+NxCppjpcg5k6xMsjhBQPTsoIh36h9Qde4WRuGpJeYnOjdosDn/cnv+OA==",
             "cpu": [
                 "x64"
             ],
@@ -1835,13 +1870,13 @@
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-linux-x64": "1.3.2"
+                "@img/sharp-libvips-linux-x64": "1.3.3"
             }
         },
         "node_modules/@img/sharp-linuxmusl-arm64": {
-            "version": "0.35.3",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz",
-            "integrity": "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==",
+            "version": "0.35.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.4.tgz",
+            "integrity": "sha512-KB5jxpfWQTr0nc3xdHtWChdbifHrBGsd2SM62Eyxrl8afikm+f5qGBU75SJIZBT/S1MC8XyacdlXBMSWq6OURA==",
             "cpu": [
                 "arm64"
             ],
@@ -1860,13 +1895,13 @@
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-linuxmusl-arm64": "1.3.2"
+                "@img/sharp-libvips-linuxmusl-arm64": "1.3.3"
             }
         },
         "node_modules/@img/sharp-linuxmusl-x64": {
-            "version": "0.35.3",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz",
-            "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
+            "version": "0.35.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.4.tgz",
+            "integrity": "sha512-f+eZJZIQNEEd26RPSW+76chwOf1XtA2Y/O+5ocVyLliHkeih3e+jhLVBdNTd2rS3IbNXK8+ug93Vf5ZXtF5Lxg==",
             "cpu": [
                 "x64"
             ],
@@ -1885,17 +1920,17 @@
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-linuxmusl-x64": "1.3.2"
+                "@img/sharp-libvips-linuxmusl-x64": "1.3.3"
             }
         },
         "node_modules/@img/sharp-wasm32": {
-            "version": "0.35.3",
-            "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
-            "integrity": "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==",
+            "version": "0.35.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.4.tgz",
+            "integrity": "sha512-zQnl4Kwp7Q6NHsENtU2T/00Zi+w3AQNwz3+UaTyVBy2FpXrzXzGjndpK61onhZjRtRpQXxCTeqw19bVyXOh7jA==",
             "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
             "optional": true,
             "dependencies": {
-                "@emnapi/runtime": "^1.11.1"
+                "@emnapi/runtime": "^1.11.3"
             },
             "engines": {
                 "node": ">=20.9.0"
@@ -1904,17 +1939,27 @@
                 "url": "https://opencollective.com/libvips"
             }
         },
+        "node_modules/@img/sharp-wasm32/node_modules/@emnapi/runtime": {
+            "version": "1.11.3",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+            "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
         "node_modules/@img/sharp-webcontainers-wasm32": {
-            "version": "0.35.3",
-            "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz",
-            "integrity": "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==",
+            "version": "0.35.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.4.tgz",
+            "integrity": "sha512-ESfNkywmCfPNyaZjxooddJQiQ+l/nTpGEOGthxiLnIHXC/CmcBixnfwUleX9mCz9ovrUUvKMap/pm8RYbzfwaA==",
             "cpu": [
                 "wasm32"
             ],
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
-                "@img/sharp-wasm32": "0.35.3"
+                "@img/sharp-wasm32": "0.35.4"
             },
             "engines": {
                 "node": ">=20.9.0"
@@ -1924,9 +1969,9 @@
             }
         },
         "node_modules/@img/sharp-win32-arm64": {
-            "version": "0.35.3",
-            "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz",
-            "integrity": "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==",
+            "version": "0.35.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.4.tgz",
+            "integrity": "sha512-iNdlBX9gLVvqe2I3uIJSIKTq6wckP/DYxZtcqxm09x5Gi24DnFBmPAWZmr60ZyYMG0xlzo6goG3670ar+RXvRw==",
             "cpu": [
                 "arm64"
             ],
@@ -1943,9 +1988,9 @@
             }
         },
         "node_modules/@img/sharp-win32-ia32": {
-            "version": "0.35.3",
-            "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz",
-            "integrity": "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==",
+            "version": "0.35.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.4.tgz",
+            "integrity": "sha512-kqRsbaa5CS6KHlpxnN7WhE6vAAugXyZButpRdvDWetlv6Qv4N9WTcrWzF7tXfB9T7MsoadqdI8hmwLq6UlLvtw==",
             "cpu": [
                 "ia32"
             ],
@@ -1962,9 +2007,9 @@
             }
         },
         "node_modules/@img/sharp-win32-x64": {
-            "version": "0.35.3",
-            "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz",
-            "integrity": "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==",
+            "version": "0.35.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.4.tgz",
+            "integrity": "sha512-XtmnYhBcrORsJ4XJngyzr/EWP0hRZLAZRFaApdKuviyqF78+ylxh2y06ZmtULAMOnObJ3ucpN0AcwSWnMowTRg==",
             "cpu": [
                 "x64"
             ],
@@ -1981,18 +2026,18 @@
             }
         },
         "node_modules/@internationalized/date": {
-            "version": "3.12.3",
-            "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.12.3.tgz",
-            "integrity": "sha512-fuLX+3ZKLsxI73y8b01EG/WjHb6gE6weCqlfawPO27kBWGMh9G1yH6Csv1uU7/cac9H2GHmOMt6CjmuQ1aia4Q==",
+            "version": "3.12.4",
+            "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.12.4.tgz",
+            "integrity": "sha512-M1dEn4c1U1HsSlaVR8upZtSqvXrTkHDfv18H01uCSJyjVLDxnBR38v/fMxecmlwXKR4i9HeZcmgQAPE6A+aGJQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@swc/helpers": "^0.5.0"
             }
         },
         "node_modules/@internationalized/number": {
-            "version": "3.6.7",
-            "resolved": "https://registry.npmjs.org/@internationalized/number/-/number-3.6.7.tgz",
-            "integrity": "sha512-3ji1fcrT+FPAK86UqEhB/psHixYo6niWPJtt7+qRaYFynt/BaJG8GhAPimtWUpEiVSTq8ZM8L5psMxGquiB/Vg==",
+            "version": "3.6.8",
+            "resolved": "https://registry.npmjs.org/@internationalized/number/-/number-3.6.8.tgz",
+            "integrity": "sha512-8UmMFia46DUt+k97zKd9fKWXcWHR+k8ae3eYzILETuT2KbIvLyOfac7zesw+sJdRAAZ7Q9pM1Mk22aXp2LD0Ig==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@swc/helpers": "^0.5.0"
@@ -2027,13 +2072,13 @@
             }
         },
         "node_modules/@intlify/core": {
-            "version": "11.4.8",
-            "resolved": "https://registry.npmjs.org/@intlify/core/-/core-11.4.8.tgz",
-            "integrity": "sha512-TGFCWeunb0mmKWpX7UXRAS2enMtucTC+NG9dT+RMfxFDCAIvXF33Wb2yJUbeNczxER4f0uMt0b9g1MCsROfKyA==",
+            "version": "11.4.10",
+            "resolved": "https://registry.npmjs.org/@intlify/core/-/core-11.4.10.tgz",
+            "integrity": "sha512-zQ/dUn7Sp7mXneQMAGp1k1h0vYDXqKWh9wQz7GCReRyx4r9kiZZOdlL/mEAexaUcph6D0gbVxHoknS+je1Em4w==",
             "license": "MIT",
             "dependencies": {
-                "@intlify/core-base": "11.4.8",
-                "@intlify/shared": "11.4.8"
+                "@intlify/core-base": "11.4.10",
+                "@intlify/shared": "11.4.10"
             },
             "engines": {
                 "node": ">= 22"
@@ -2043,14 +2088,14 @@
             }
         },
         "node_modules/@intlify/core-base": {
-            "version": "11.4.8",
-            "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-11.4.8.tgz",
-            "integrity": "sha512-A+Q7SKm5oEcy1E/cghqd7n/St4XjTqLhiiyDuieNcMrJcrHlkY5n0jp7Q9dD3txvVHzvsmBVV5M9wD5/s1zfzw==",
+            "version": "11.4.10",
+            "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-11.4.10.tgz",
+            "integrity": "sha512-+yJ74JRWVJokdgG9zYNMyTSzeNV3O9T4vVxk8PvLFHmI+R/BYA//cITh7vhRK37hWLZ4/kTcKcUz1dlWOpypIg==",
             "license": "MIT",
             "dependencies": {
-                "@intlify/devtools-types": "11.4.8",
-                "@intlify/message-compiler": "11.4.8",
-                "@intlify/shared": "11.4.8"
+                "@intlify/devtools-types": "11.4.10",
+                "@intlify/message-compiler": "11.4.10",
+                "@intlify/shared": "11.4.10"
             },
             "engines": {
                 "node": ">= 22"
@@ -2060,13 +2105,13 @@
             }
         },
         "node_modules/@intlify/devtools-types": {
-            "version": "11.4.8",
-            "resolved": "https://registry.npmjs.org/@intlify/devtools-types/-/devtools-types-11.4.8.tgz",
-            "integrity": "sha512-MGpID+rlfzGUbNcnC20bm5NMSBHPrvx0atLTfv9dftn3kjXw1hGKDcIcwrO99tSrZEc2i+hczRL7ks8qXsHPkQ==",
+            "version": "11.4.10",
+            "resolved": "https://registry.npmjs.org/@intlify/devtools-types/-/devtools-types-11.4.10.tgz",
+            "integrity": "sha512-xZxzZsAuu6/0zoLRVQWdpXWe5Kjl0LnWpjlQA3r9u9FbLYMhapqt7IwkgQyn0Tm2GUNAqhj9eZiUmYOrB024BQ==",
             "license": "MIT",
             "dependencies": {
-                "@intlify/core-base": "11.4.8",
-                "@intlify/shared": "11.4.8"
+                "@intlify/core-base": "11.4.10",
+                "@intlify/shared": "11.4.10"
             },
             "engines": {
                 "node": ">= 22"
@@ -2104,12 +2149,12 @@
             }
         },
         "node_modules/@intlify/message-compiler": {
-            "version": "11.4.8",
-            "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-11.4.8.tgz",
-            "integrity": "sha512-vbzk17dYwduYiv52EK61+FDCyhfVg1uPUtPmiD/d45W99uJIcXywrweOBcHv7n9/iEqmXiMGT52bgJbZDQqK3w==",
+            "version": "11.4.10",
+            "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-11.4.10.tgz",
+            "integrity": "sha512-oUB/scz2EJENXDiUJ7JjZffOrH8UIZ1BuZeHvonbi5fWLavLt04aivuk2OIByOZA0tsci1bkeeQRmwhb5M8Imw==",
             "license": "MIT",
             "dependencies": {
-                "@intlify/shared": "11.4.8",
+                "@intlify/shared": "11.4.10",
                 "source-map-js": "^1.0.2"
             },
             "engines": {
@@ -2120,9 +2165,9 @@
             }
         },
         "node_modules/@intlify/shared": {
-            "version": "11.4.8",
-            "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-11.4.8.tgz",
-            "integrity": "sha512-XbRgrv+XEuvDr7UCY55oibVrh+o4u+A0VB6nSL0F5Z8LcZxE/8j573LYG6bCrOigIcHdGpSNI7Rh5UpC5/B/eg==",
+            "version": "11.4.10",
+            "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-11.4.10.tgz",
+            "integrity": "sha512-FeImVdPeoSHTm3NBFFZHv0eRP9gQ3F4lj2puDBX5Kw7iiM1uJW6JTf39ian0K/17pbXCI3ef5i9RVsRrALqI6Q==",
             "license": "MIT",
             "engines": {
                 "node": ">= 22"
@@ -2173,13 +2218,13 @@
             }
         },
         "node_modules/@intlify/unplugin-vue-i18n/node_modules/@typescript-eslint/project-service": {
-            "version": "8.68.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.68.0.tgz",
-            "integrity": "sha512-5GQtWZCXFcFYux955pvoS02WLc49pXNlvIxocKjS0clvwo3in1RdlzVKyiqQH9vE5AKWFLTaUgeQkOrTS+0Qxw==",
+            "version": "8.69.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.69.0.tgz",
+            "integrity": "sha512-yi4obFrHMmnsesWehHbkg9zMA7Jt8cXT+mKM08G999pH1yT6nqgsHx7MYm0uY1wAj8CqiBXYRJ7WAT0QdQHQXg==",
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/tsconfig-utils": "^8.68.0",
-                "@typescript-eslint/types": "^8.68.0",
+                "@typescript-eslint/tsconfig-utils": "^8.69.0",
+                "@typescript-eslint/types": "^8.69.0",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -2194,9 +2239,9 @@
             }
         },
         "node_modules/@intlify/unplugin-vue-i18n/node_modules/@typescript-eslint/tsconfig-utils": {
-            "version": "8.68.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.68.0.tgz",
-            "integrity": "sha512-F7zrGQfiJHojPwi8vhxZQC1tWtJzvL74cK/nqri2lk8YUXvYaYwl263xOJ69jDWPUk1hmcdoayFwk9lX09npVw==",
+            "version": "8.69.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.69.0.tgz",
+            "integrity": "sha512-xNqK7YTDZsLniQMV/4rpFR8Z5JlqeRvVjuG1YgF/mdPVH84HSD19L8CczMA0qg2RfwEV231GHH3VnToJDo4MfQ==",
             "license": "MIT",
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2209,29 +2254,16 @@
                 "typescript": ">=4.8.4 <6.1.0"
             }
         },
-        "node_modules/@intlify/unplugin-vue-i18n/node_modules/@typescript-eslint/types": {
-            "version": "8.68.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.68.0.tgz",
-            "integrity": "sha512-9RnpsGJjrAllCMefGVVsImJM24YurhC0Q1h4UbvivtvOqXmR/vEJge2OoE++z9m6hyg8T1Q8t5SNT6tHSbrxcg==",
-            "license": "MIT",
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            }
-        },
         "node_modules/@intlify/unplugin-vue-i18n/node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.68.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.68.0.tgz",
-            "integrity": "sha512-OKKsD0tYmoNiU5PW2zehO1yO56jYOm1ShYlxon/Z0SJNidAkdVg86eg9ruRuoXf8xfnuWZGbwDsStkoXbZtIIA==",
+            "version": "8.69.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.69.0.tgz",
+            "integrity": "sha512-AdFkgqck3Vudb/kWnxlyafU/4aBhHrbQ9locP2N4psXTy5mOBg0SHJumnLvx7r6g1gV4DKvUFwV2nJZBoqOD8w==",
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/project-service": "8.68.0",
-                "@typescript-eslint/tsconfig-utils": "8.68.0",
-                "@typescript-eslint/types": "8.68.0",
-                "@typescript-eslint/visitor-keys": "8.68.0",
+                "@typescript-eslint/project-service": "8.69.0",
+                "@typescript-eslint/tsconfig-utils": "8.69.0",
+                "@typescript-eslint/types": "8.69.0",
+                "@typescript-eslint/visitor-keys": "8.69.0",
                 "debug": "^4.4.3",
                 "minimatch": "^10.2.2",
                 "semver": "^7.7.3",
@@ -2247,35 +2279,6 @@
             },
             "peerDependencies": {
                 "typescript": ">=4.8.4 <6.1.0"
-            }
-        },
-        "node_modules/@intlify/unplugin-vue-i18n/node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.68.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.68.0.tgz",
-            "integrity": "sha512-YR65gGdGvTUAWLldC3xLOvOzamdGzB4A5/N8rehEaHs3Zvoe39BhgY+u0SPch1OvrVTfLcc55wsSgK2NcnTS/A==",
-            "license": "MIT",
-            "dependencies": {
-                "@typescript-eslint/types": "8.68.0",
-                "eslint-visitor-keys": "^5.0.0"
-            },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            }
-        },
-        "node_modules/@intlify/unplugin-vue-i18n/node_modules/eslint-visitor-keys": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
-            "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
-            "license": "Apache-2.0",
-            "engines": {
-                "node": "^20.19.0 || ^22.13.0 || >=24"
-            },
-            "funding": {
-                "url": "https://opencollective.com/eslint"
             }
         },
         "node_modules/@intlify/unplugin-vue-i18n/node_modules/typescript": {
@@ -2534,9 +2537,9 @@
             }
         },
         "node_modules/@jridgewell/sourcemap-codec": {
-            "version": "1.5.5",
-            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
-            "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.6.0.tgz",
+            "integrity": "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==",
             "license": "MIT"
         },
         "node_modules/@jridgewell/trace-mapping": {
@@ -2548,6 +2551,30 @@
                 "@jridgewell/resolve-uri": "^3.1.0",
                 "@jridgewell/sourcemap-codec": "^1.4.14"
             }
+        },
+        "node_modules/@keyv/bigmap": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/@keyv/bigmap/-/bigmap-1.3.1.tgz",
+            "integrity": "sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "hashery": "^1.4.0",
+                "hookified": "^1.15.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            },
+            "peerDependencies": {
+                "keyv": "^5.6.0"
+            }
+        },
+        "node_modules/@keyv/serialize": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
+            "integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@kwsites/file-exists": {
             "version": "1.1.1",
@@ -2679,9 +2706,9 @@
             }
         },
         "node_modules/@noble/hashes": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.3.0.tgz",
-            "integrity": "sha512-oN+QwyX7VSHotibwubG3kpzbwKrfnyR6OOO+3Nk/53ADL7FmgHHz4TgrbaYKvvOw09u6QTx0oiH1cNCIOuN0CQ==",
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.4.0.tgz",
+            "integrity": "sha512-X5XaVWZIBCT7HHZGm5I7ZQXDwLG+bGXuSrMQAW+7Zvl87h1kmc1ZB1VSRJcpUfoUrGQp4Fkoxm5kZ+Ms+aW+eA==",
             "license": "MIT",
             "engines": {
                 "node": ">= 20.19.0"
@@ -2790,6 +2817,160 @@
                 "node": ">=20.16.0"
             }
         },
+        "node_modules/@nuxt/content": {
+            "version": "3.16.0",
+            "resolved": "https://registry.npmjs.org/@nuxt/content/-/content-3.16.0.tgz",
+            "integrity": "sha512-UdPZafE7fyXBJSKOY8b9B84f7YM5Kp48q8vGKxDLaGHOnhuRCOaM/mmOkJUjurSwbJDK9DD1thpIUg+CFHPNeA==",
+            "license": "MIT",
+            "dependencies": {
+                "@nuxt/kit": "^4.5.2",
+                "@nuxtjs/mdc": "^0.23.1",
+                "@shikijs/langs": "^4.4.3",
+                "@sqlite.org/sqlite-wasm": "3.53.0-build1",
+                "@standard-schema/spec": "^1.1.0",
+                "@webcontainer/env": "^1.1.1",
+                "c12": "^3.3.4",
+                "chokidar": "^5.0.0",
+                "consola": "^3.4.2",
+                "db0": "^0.4.0",
+                "defu": "^6.1.7",
+                "destr": "^2.0.5",
+                "git-url-parse": "^16.1.0",
+                "h3": "^1.15.11",
+                "hookable": "^5.5.3",
+                "isomorphic-git": "^1.41.9",
+                "jiti": "^2.7.0",
+                "json-schema-to-typescript-lite": "^15.0.0",
+                "mdast-util-to-hast": "^13.2.1",
+                "mdast-util-to-string": "^4.0.0",
+                "micromark": "^4.0.2",
+                "micromark-util-character": "^2.1.1",
+                "micromark-util-chunked": "^2.0.1",
+                "micromark-util-resolve-all": "^2.0.1",
+                "micromark-util-sanitize-uri": "^2.0.1",
+                "micromatch": "^4.0.8",
+                "minimark": "^0.2.0",
+                "minimatch": "^10.2.6",
+                "nuxt-component-meta": "0.18.0",
+                "nypm": "^0.6.9",
+                "ohash": "^2.0.12",
+                "pathe": "^2.0.3",
+                "pkg-types": "^2.3.1",
+                "remark-mdc": "^3.11.1",
+                "scule": "^1.3.0",
+                "shiki": "^4.4.3",
+                "slugify": "^1.6.9",
+                "socket.io-client": "^4.8.3",
+                "std-env": "^4.2.0",
+                "tinyglobby": "^0.2.17",
+                "ufo": "^1.6.4",
+                "unctx": "^3.0.1",
+                "unified": "^11.0.5",
+                "unist-util-stringify-position": "^4.0.0",
+                "unist-util-visit": "^5.1.0",
+                "unplugin": "^3.3.0",
+                "zod": "^3.25.76",
+                "zod-to-json-schema": "^3.25.2"
+            },
+            "engines": {
+                "node": ">= 20.19.0"
+            },
+            "peerDependencies": {
+                "@electric-sql/pglite": "*",
+                "@libsql/client": "*",
+                "@valibot/to-json-schema": "^1.5.0",
+                "better-sqlite3": "^12.5.0 || ^13.0.0",
+                "sqlite3": "*",
+                "valibot": "^1.2.0"
+            },
+            "peerDependenciesMeta": {
+                "@electric-sql/pglite": {
+                    "optional": true
+                },
+                "@libsql/client": {
+                    "optional": true
+                },
+                "@valibot/to-json-schema": {
+                    "optional": true
+                },
+                "better-sqlite3": {
+                    "optional": true
+                },
+                "sqlite3": {
+                    "optional": true
+                },
+                "valibot": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@nuxt/content/node_modules/@nuxtjs/mdc": {
+            "version": "0.23.1",
+            "resolved": "https://registry.npmjs.org/@nuxtjs/mdc/-/mdc-0.23.1.tgz",
+            "integrity": "sha512-H+e/eO/Uj5Apb3YwFQs3X0e6HsIPYEm++/lEDFGuQCvPxUh89idhsZRnYQ5EQgAMge5uTS2hmSYIH4mX8xj+Hw==",
+            "license": "MIT",
+            "dependencies": {
+                "@nuxt/kit": "^4.5.1",
+                "@shikijs/core": "^4.4.2",
+                "@shikijs/engine-javascript": "^4.4.2",
+                "@shikijs/langs": "^4.4.2",
+                "@shikijs/themes": "^4.4.2",
+                "@shikijs/transformers": "^4.4.2",
+                "@types/hast": "^3.0.5",
+                "@types/mdast": "^4.0.4",
+                "@vue/compiler-core": "^3.5.41",
+                "consola": "^3.4.2",
+                "debug": "^4.4.3",
+                "defu": "^6.1.7",
+                "destr": "^2.0.5",
+                "detab": "^3.0.2",
+                "github-slugger": "^2.0.0",
+                "hast-util-format": "^1.1.0",
+                "hast-util-to-mdast": "^10.1.2",
+                "hast-util-to-string": "^3.0.1",
+                "mdast-util-to-hast": "^13.2.1",
+                "micromark-util-sanitize-uri": "^2.0.1",
+                "parse5": "^8.0.1",
+                "pathe": "^2.0.3",
+                "property-information": "^7.2.0",
+                "rehype-external-links": "^3.0.0",
+                "rehype-minify-whitespace": "^6.0.2",
+                "rehype-raw": "^7.0.0",
+                "rehype-remark": "^10.0.1",
+                "rehype-slug": "^6.0.0",
+                "rehype-sort-attribute-values": "^5.0.1",
+                "rehype-sort-attributes": "^5.0.1",
+                "remark-emoji": "^5.0.2",
+                "remark-gfm": "^4.0.1",
+                "remark-mdc": "^3.11.1",
+                "remark-parse": "^11.0.0",
+                "remark-rehype": "^11.1.2",
+                "remark-stringify": "^11.0.0",
+                "scule": "^1.3.0",
+                "shiki": "^4.4.2",
+                "ufo": "^1.6.4",
+                "unified": "^11.0.5",
+                "unist-builder": "^4.0.0",
+                "unist-util-visit": "^5.1.0",
+                "unwasm": "^0.5.3",
+                "vfile": "^6.0.3"
+            }
+        },
+        "node_modules/@nuxt/content/node_modules/hookable": {
+            "version": "5.5.3",
+            "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
+            "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
+            "license": "MIT"
+        },
+        "node_modules/@nuxt/content/node_modules/zod": {
+            "version": "3.25.76",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+            "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/colinhacks"
+            }
+        },
         "node_modules/@nuxt/devalue": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/@nuxt/devalue/-/devalue-2.0.2.tgz",
@@ -2797,13 +2978,13 @@
             "license": "MIT"
         },
         "node_modules/@nuxt/devtools": {
-            "version": "3.4.1",
-            "resolved": "https://registry.npmjs.org/@nuxt/devtools/-/devtools-3.4.1.tgz",
-            "integrity": "sha512-20zZs6k/zAdi+PM7s1BwxE3hanZ+R1OGi5DWCKPyzSnhUUeeNebvWNgec7Rwnx6iKLkJfK4WFIZ+FL2QurG/ZQ==",
+            "version": "3.4.2",
+            "resolved": "https://registry.npmjs.org/@nuxt/devtools/-/devtools-3.4.2.tgz",
+            "integrity": "sha512-Nidg0/zB710cyK89ltTkv66hMfPlIPlKA+Yb67bIrAkNm5PoTwQ1goHdFWHIAGZ9nTadcVTzATwMwa56nvl/Wg==",
             "license": "MIT",
             "dependencies": {
-                "@nuxt/devtools-kit": "3.4.1",
-                "@nuxt/devtools-wizard": "3.4.1",
+                "@nuxt/devtools-kit": "3.4.2",
+                "@nuxt/devtools-wizard": "3.4.2",
                 "@nuxt/kit": "^4.5.1",
                 "@vue/devtools-core": "^8.2.1",
                 "@vue/devtools-kit": "^8.2.1",
@@ -2850,9 +3031,9 @@
             }
         },
         "node_modules/@nuxt/devtools-kit": {
-            "version": "3.4.1",
-            "resolved": "https://registry.npmjs.org/@nuxt/devtools-kit/-/devtools-kit-3.4.1.tgz",
-            "integrity": "sha512-6ltPm2yUW8GvDdf3VJna7+flLi+ej7xRfSr+S4ovevKt/CuPf9EqYOn1jW7Kw/U1MXt/71zkn+/O2vu3G6O9Hg==",
+            "version": "3.4.2",
+            "resolved": "https://registry.npmjs.org/@nuxt/devtools-kit/-/devtools-kit-3.4.2.tgz",
+            "integrity": "sha512-TPPbmH9xrExagYxfCe6JgtbHmgchfgDdA656Yws18rn8I/oCvB+gcw3kTWBBp2sC9ipZPXsgbsW/yZnVnGNBiA==",
             "license": "MIT",
             "dependencies": {
                 "@nuxt/kit": "^4.5.1",
@@ -2863,9 +3044,9 @@
             }
         },
         "node_modules/@nuxt/devtools-wizard": {
-            "version": "3.4.1",
-            "resolved": "https://registry.npmjs.org/@nuxt/devtools-wizard/-/devtools-wizard-3.4.1.tgz",
-            "integrity": "sha512-taGeuTnkHsZVjgD9r6NXvvHaBzB2j4mCgOmlmkz3ntsqgh1SJfmsD11Tmtl7FVAxJS8Wuvuzgt0GyTlADBW9Wg==",
+            "version": "3.4.2",
+            "resolved": "https://registry.npmjs.org/@nuxt/devtools-wizard/-/devtools-wizard-3.4.2.tgz",
+            "integrity": "sha512-U2G8fw7KW1rdECyJDho5N14z8hSllpTk430KG1QPLjrv5w3pDksZ+YcpITd0u762Vw3gq3Arpg65Bk6U4ua6aQ==",
             "license": "MIT",
             "dependencies": {
                 "@clack/prompts": "^1.7.0",
@@ -2948,19 +3129,6 @@
                 "std-env": "^4.2.0",
                 "tinyglobby": "^0.2.17",
                 "ufo": "^1.6.4"
-            }
-        },
-        "node_modules/@nuxt/icon/node_modules/@nuxt/devtools-kit": {
-            "version": "3.4.2",
-            "resolved": "https://registry.npmjs.org/@nuxt/devtools-kit/-/devtools-kit-3.4.2.tgz",
-            "integrity": "sha512-TPPbmH9xrExagYxfCe6JgtbHmgchfgDdA656Yws18rn8I/oCvB+gcw3kTWBBp2sC9ipZPXsgbsW/yZnVnGNBiA==",
-            "license": "MIT",
-            "dependencies": {
-                "@nuxt/kit": "^4.5.1",
-                "execa": "^8.0.1"
-            },
-            "peerDependencies": {
-                "vite": ">=6.0"
             }
         },
         "node_modules/@nuxt/image": {
@@ -3177,16 +3345,15 @@
             }
         },
         "node_modules/@nuxt/telemetry": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/@nuxt/telemetry/-/telemetry-2.8.0.tgz",
-            "integrity": "sha512-zAwXY24KYvpLTmiV+osagd2EHkfs5IF+7oDZYTQoit5r0kPlwaCNlzHp5I/wUAWT4LBw6lG8gZ6bWidAdv/erQ==",
+            "version": "2.9.1",
+            "resolved": "https://registry.npmjs.org/@nuxt/telemetry/-/telemetry-2.9.1.tgz",
+            "integrity": "sha512-WYQs6GvebU278YXhbGlLA8pUO3ox+juHAiKCB3SEH0lq2PDRwX465tHRtpVIqsHv+lGK/n99FC7qqyBt9+p3oQ==",
             "license": "MIT",
             "dependencies": {
-                "citty": "^0.2.1",
+                "citty": "^0.2.2",
                 "consola": "^3.4.2",
-                "ofetch": "^2.0.0-alpha.3",
-                "rc9": "^3.0.0",
-                "std-env": "^4.0.0"
+                "rc9": "^3.0.1",
+                "std-env": "^4.2.0"
             },
             "bin": {
                 "nuxt-telemetry": "bin/nuxt-telemetry.mjs"
@@ -3197,12 +3364,6 @@
             "peerDependencies": {
                 "@nuxt/kit": ">=3.0.0"
             }
-        },
-        "node_modules/@nuxt/telemetry/node_modules/ofetch": {
-            "version": "2.0.0-alpha.3",
-            "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-2.0.0-alpha.3.tgz",
-            "integrity": "sha512-zpYTCs2byOuft65vI3z43Dd6iSdFbOZZLb9/d21aCpx2rGastVU9dOCv0lu4ykc1Ur1anAYjDi3SUvR0vq50JA==",
-            "license": "MIT"
         },
         "node_modules/@nuxt/ui": {
             "version": "4.11.0",
@@ -3894,24 +4055,24 @@
             }
         },
         "node_modules/@nuxtjs/mcp-toolkit": {
-            "version": "0.17.2",
-            "resolved": "https://registry.npmjs.org/@nuxtjs/mcp-toolkit/-/mcp-toolkit-0.17.2.tgz",
-            "integrity": "sha512-8/4d/QTc6KfUTml8IlQ2mrznszQcBCribciz+wogbCL+YCrKjqbzSz8azaQ8MvqdSHk1h3acTL4qdkLNLurLlA==",
+            "version": "0.19.0",
+            "resolved": "https://registry.npmjs.org/@nuxtjs/mcp-toolkit/-/mcp-toolkit-0.19.0.tgz",
+            "integrity": "sha512-sKTlK+x2WXPPoOFQ6DkhN+3KDM0IeTms8/T3mvuDV6GuDxKASqqAKlIkkoGQ266+x/YvT1XPChGwQ7ROKqEASQ==",
             "license": "MIT",
             "dependencies": {
-                "@modelcontextprotocol/sdk": "^1.29.0",
-                "@nuxt/kit": "^4.4.6",
-                "@vitejs/plugin-vue": "^6.0.7",
-                "tinyglobby": "^0.2.16",
+                "@modelcontextprotocol/sdk": "^1.30.0",
+                "@nuxt/kit": "^4.5.2",
+                "@vitejs/plugin-vue": "^6.0.8",
+                "tinyglobby": "^0.2.17",
                 "vite-plugin-singlefile": "^2.3.3"
             },
             "peerDependencies": {
-                "@vue/compiler-sfc": "^3.5.34",
-                "agents": ">=0.12.4",
+                "@vue/compiler-sfc": "^3.5.41",
+                "agents": ">=0.20.1",
                 "h3": ">=1.15.11",
-                "secure-exec": ">=0.2.1",
+                "secure-exec": ">=0.3.3",
                 "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
-                "vue": "^3.5.34",
+                "vue": "^3.5.41",
                 "zod": "^4.1.13"
             },
             "peerDependenciesMeta": {
@@ -3991,9 +4152,9 @@
             }
         },
         "node_modules/@nuxtjs/robots": {
-            "version": "6.1.5",
-            "resolved": "https://registry.npmjs.org/@nuxtjs/robots/-/robots-6.1.5.tgz",
-            "integrity": "sha512-OChySf7k4HXg5K/A+I8fE0szT8ia9CS3A2EXYMPVcJ0IZch9u4qxBqapBkphqODXbx152fgfCVedHC02p8qCXg==",
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/@nuxtjs/robots/-/robots-6.2.0.tgz",
+            "integrity": "sha512-+y8BRDWOkSMofe0ewOlVQm6+VFd4Qh/I8kh9z/++VwfPlDtrU6BDhoobJ18eVDaMkf8gJl12dwKZziK8yU4c/g==",
             "license": "MIT",
             "dependencies": {
                 "@fingerprintjs/botd": "^2.0.0",
@@ -4001,8 +4162,8 @@
                 "consola": "^3.4.2",
                 "defu": "^6.1.7",
                 "h3": "^1.15.11",
-                "nuxt-site-config": "^4.2.0",
-                "nuxtseo-shared": "^5.3.11",
+                "nuxt-site-config": "^4.2.3",
+                "nuxtseo-shared": "^5.3.14",
                 "pathe": "^2.0.3",
                 "pkg-types": "^2.3.1",
                 "ufo": "^1.6.4"
@@ -4017,15 +4178,6 @@
                 "zod": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/@opentelemetry/api": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
-            "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=8.0.0"
             }
         },
         "node_modules/@oxc-parser/binding-android-arm-eabi": {
@@ -4809,38 +4961,26 @@
             "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
             "license": "MIT"
         },
-        "node_modules/@quansync/fs": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@quansync/fs/-/fs-1.0.0.tgz",
-            "integrity": "sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==",
+        "node_modules/@rolldown/binding-android-arm-eabi": {
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm-eabi/-/binding-android-arm-eabi-1.2.7.tgz",
+            "integrity": "sha512-EypzgnYCwyVY4NDHKzGmNJT5b+XaQEBniHxsMdeIQLB/tcCzZnhqrzHpZFbX9iaxx+5RiB8caATBtfvZP7zVxQ==",
+            "cpu": [
+                "arm"
+            ],
             "license": "MIT",
-            "dependencies": {
-                "quansync": "^1.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sxzz"
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
             }
         },
-        "node_modules/@quansync/fs/node_modules/quansync": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/quansync/-/quansync-1.0.0.tgz",
-            "integrity": "sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA==",
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://github.com/sponsors/antfu"
-                },
-                {
-                    "type": "individual",
-                    "url": "https://github.com/sponsors/sxzz"
-                }
-            ],
-            "license": "MIT"
-        },
         "node_modules/@rolldown/binding-android-arm64": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.4.tgz",
-            "integrity": "sha512-jHC2cnyKz5xU2fhECtFl8OZ83cYNt13GZQD+0uMJ/X3o+ijmd56okHhTUwxVSHPx1IRVIJEZ1/1pPzeLCU6XKA==",
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.7.tgz",
+            "integrity": "sha512-l17HE9EweWaqJZhuUuNBN/FzM62xw+DECVnJyvMsxn8vJFAGLy5QfLDoYAcronkAN8VxKZHezDpulHDPx95vFw==",
             "cpu": [
                 "arm64"
             ],
@@ -4854,9 +4994,9 @@
             }
         },
         "node_modules/@rolldown/binding-darwin-arm64": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.4.tgz",
-            "integrity": "sha512-Dc5mPD8F5F/FS8i01syd7FTF6yB2fVthH/TRkjwJkzUK6EpoxHtqvZQP5Zwq80/5z19TWYHIg1KOHboCgVx/aQ==",
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.7.tgz",
+            "integrity": "sha512-8ED8ELFvHXc6OCETIn4gXObPiaR6bckM/ipXtbzlPVDRMBfEGjCKgO90F9YtfdpDatVx/ZQw7aZ1vUMf/+T3Mw==",
             "cpu": [
                 "arm64"
             ],
@@ -4870,9 +5010,9 @@
             }
         },
         "node_modules/@rolldown/binding-darwin-x64": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.4.tgz",
-            "integrity": "sha512-fpDm4oBo6SqLvWUYCmFhdde3U9KH2fRNNMeAnAPAIwxRL345xutL0EtEUcuoxsoazdJGv/MuDBQHlCDrtbvqOg==",
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.7.tgz",
+            "integrity": "sha512-/WPripjtiAIZ2tWY7ddijORT0Ujg87wxWW/qcoFVCKAWVDPhtY0xr7Dj0M3GyNGz60jGwTElhro/mkF9dT7dDQ==",
             "cpu": [
                 "x64"
             ],
@@ -4886,9 +5026,9 @@
             }
         },
         "node_modules/@rolldown/binding-freebsd-x64": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.4.tgz",
-            "integrity": "sha512-rSJoreDE/HoIzoaib6MTp5jQtCTdMHKIvItAKT/ImS6Y6Ww76oUaeMyp4Vc/fAgd/ehji068IxetHXAnqUwN9A==",
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.7.tgz",
+            "integrity": "sha512-14DI4NcqpvbICxSnGLx3PmtDaWqRP/KGSGb6C+JLLVPeZRl6dKdHba3pGsqT3vpdTqhEYIPG0MMQ8c0xYqoJxA==",
             "cpu": [
                 "x64"
             ],
@@ -4902,9 +5042,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.4.tgz",
-            "integrity": "sha512-/jm8OGHgn7oGaJu3i/qZI9spUGcJ+y/lk43ttQ/iO1tOd9NissG6o97bighBCiL+BKRngmcDuR6ikfwYdJmVuQ==",
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.7.tgz",
+            "integrity": "sha512-bxrWIRvHWQvbJwi+VIie/kDJmQxcNE6xxWwZdqF/ExVAigtHkv54WTLQPb+QsZdnFy18fg7JPfWGL0RH6vwIlQ==",
             "cpu": [
                 "arm"
             ],
@@ -4918,9 +5058,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm64-gnu": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.4.tgz",
-            "integrity": "sha512-tIP06BeD9EqvECBrPZ+sqdPlYrT+aYaAiu1wYziVx5elRK/ftm33JxVDy2bXGbr6J0CrtirCkR87/X5a2euEng==",
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.7.tgz",
+            "integrity": "sha512-toOY2BChBZyuxU7OYX6Tn389di4IzAqPTycVcci0O7FSfBqzRB3RZn+K5Is6ANf4tmgRd/K1yZTsNTXbkXsnLg==",
             "cpu": [
                 "arm64"
             ],
@@ -4937,9 +5077,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm64-musl": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.4.tgz",
-            "integrity": "sha512-Ql1Q0EQqVThvn9VAVlwNzsUvbSFtCMGjLpRRi4pk5i7NZZ4n5ISiLMjHYtus4VQ2PvkSw24zyaCVsiS+sXPj1w==",
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.7.tgz",
+            "integrity": "sha512-lAIXTH/aiLRLxsTgQvfhjo4K1ydWIp00+V0voOr9beb/9ZmkUFrSIb03dXNFRgMNvkE6oGsF10ioQ6UsI+vS5Q==",
             "cpu": [
                 "arm64"
             ],
@@ -4956,9 +5096,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.4.tgz",
-            "integrity": "sha512-GjbjXD4XXfN19D0LZNbmiCBUoDiRACsYHr0yaIbbn8aFsXjHZifcYqu/W5Er5X2X990WjHXFrxarn5chzItorQ==",
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.7.tgz",
+            "integrity": "sha512-kdnwS28Pkenp/mZMRwjXXXwxQ7pIsm+bF919LUK93BOyhcLsrVKdP2p9fxpiPNPAbNuch8ypQt0pm2P2LYCAGg==",
             "cpu": [
                 "ppc64"
             ],
@@ -4975,9 +5115,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-s390x-gnu": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.4.tgz",
-            "integrity": "sha512-p5WR0NOwaRmJ/B1b6IjEFLLivwEsf3PrdBIhRbhTCQisbo2SvHHpG4ELB/+FgQNnB88LTOF86upmJmbvZdQ2lw==",
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.7.tgz",
+            "integrity": "sha512-516OdsyLdr5E65paF3yBF55t8mfm9+gmtCsK3xI7XKXIT7EfRlHhxL8K/NR6Hu8BWSgF5+1w74lTL0+nxcc8Qw==",
             "cpu": [
                 "s390x"
             ],
@@ -4994,9 +5134,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-x64-gnu": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.4.tgz",
-            "integrity": "sha512-4/GyVjmhR+Tc6HLJvwc1sOhPqAZtySiSMesOZyX6JQ5XBxoTDEMKQzvo07NIK6nTon/SivlZqvhzvuVBNQhObQ==",
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.7.tgz",
+            "integrity": "sha512-r8/z8n7GFaYRln3xmP1Cxy0HH/HLM0uBUPkEuSVEfKGDA89M0FsZRZJRSwe/tJjRx+fpH/gjorfhB8tmEbSFLA==",
             "cpu": [
                 "x64"
             ],
@@ -5013,9 +5153,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-x64-musl": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.4.tgz",
-            "integrity": "sha512-l9eeLsCNvPpmSXUej0etw/J1eqV0Jj1D5G/xG6YTijmE6dkv6E2QezgWbTfQk63v952DPqrjOCoiqxq7Bw0YUQ==",
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.7.tgz",
+            "integrity": "sha512-pAsE8iiDxUg1xBqdhrTfg45AVDVpirjz00sblEYClGNNcMnDb+e8beQgqIAw6LvauX/APvgxUnwrgun/YYGBhw==",
             "cpu": [
                 "x64"
             ],
@@ -5032,9 +5172,9 @@
             }
         },
         "node_modules/@rolldown/binding-openharmony-arm64": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.4.tgz",
-            "integrity": "sha512-e0F355MSTMm3+UOqtV3L24gFUp2N5m1f8L/7d56deik6va+AXdrt9F8LbzGpeWGWRbZEDq4m8NVnJDeBtf9DZg==",
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.7.tgz",
+            "integrity": "sha512-lTcIYmmnQQA8Or/2DatS6oSqcdLHvendjS+zLu+FwgToynWMRSmQdpM65fTANJgIS4mjbMOo5KT2lnT9SAb96w==",
             "cpu": [
                 "arm64"
             ],
@@ -5048,9 +5188,9 @@
             }
         },
         "node_modules/@rolldown/binding-win32-arm64-msvc": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.4.tgz",
-            "integrity": "sha512-AWLi0uBRYh6QlE7OKhiz+phZC0qwtij2QZmhmOdsLdFn64m7oMpooE9ICE3lhm9xMb4SpDo2WbHcxX1iFLFtqw==",
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.7.tgz",
+            "integrity": "sha512-e3Gu3WxbNk/UqQhxqU7YIYO+9ZBvWNz3U+h/qRFosscMFzdRPbXYSaSWgSnklv2fz1TgzBTcti2z35c/7irsHw==",
             "cpu": [
                 "arm64"
             ],
@@ -5064,9 +5204,9 @@
             }
         },
         "node_modules/@rolldown/binding-win32-x64-msvc": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.4.tgz",
-            "integrity": "sha512-UwSDJOg3dqCAejWdxclJjCsh3Qq4vLYMDxmyHqo1btz3stK2VqgwNd3mm5tuIwzSlGIQ/1H9Hr+Zn09mrezNqQ==",
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.7.tgz",
+            "integrity": "sha512-W/jg5qoRSqjsEv0+dZi4e687mcHqmVuU0P4fK6qS/xjetW2Gmc1W8j//z5nAeNcC8Ttm0hV46IjcYeuVwYhuiw==",
             "cpu": [
                 "x64"
             ],
@@ -5309,9 +5449,9 @@
             }
         },
         "node_modules/@rollup/rollup-android-arm-eabi": {
-            "version": "4.62.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.4.tgz",
-            "integrity": "sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==",
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.63.1.tgz",
+            "integrity": "sha512-UZ8sUxPTiHWYX9QNdJedb1kDZSpS1t/VPWBWGSgqHNi9w3Cu6IXvu2mzbhiTiPvtrqgTQJ+zqiAq2iPIPilpaQ==",
             "cpu": [
                 "arm"
             ],
@@ -5322,9 +5462,9 @@
             ]
         },
         "node_modules/@rollup/rollup-android-arm64": {
-            "version": "4.62.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.4.tgz",
-            "integrity": "sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==",
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.63.1.tgz",
+            "integrity": "sha512-cQ4nFQABN5cDvDpbvJ7bMStCpnaVxynZrRMfUJYgxcIk9Sh54FIO1vtfkg0B69REjER77ioZ/ov+eAApx/KmLQ==",
             "cpu": [
                 "arm64"
             ],
@@ -5335,9 +5475,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-arm64": {
-            "version": "4.62.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.4.tgz",
-            "integrity": "sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==",
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.63.1.tgz",
+            "integrity": "sha512-FQNqd1lRy/0QhDk3xeRIkSBiCpXCiDnZO3YLVdcDKN1UBiKToNftCzcXYNLshmPDUMlu2TdeS8tGcsU6f3YF1Q==",
             "cpu": [
                 "arm64"
             ],
@@ -5348,9 +5488,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-x64": {
-            "version": "4.62.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.4.tgz",
-            "integrity": "sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==",
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.63.1.tgz",
+            "integrity": "sha512-pvD16V939D3CloK0+qikpGaxiPrDUXTe7Y5cWOMkMSy7m1cawa8EGy/kXYi/G/cKAC4HDAbSnzCIk1WmsoOKXg==",
             "cpu": [
                 "x64"
             ],
@@ -5361,9 +5501,9 @@
             ]
         },
         "node_modules/@rollup/rollup-freebsd-arm64": {
-            "version": "4.62.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.4.tgz",
-            "integrity": "sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==",
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.63.1.tgz",
+            "integrity": "sha512-pcFGeL2345VwdTnJhA6zLbew+YgWB0qBG2+dMtXjCicf6+rm6kO6cOoh5VnTe0ZMrMRgRyuHmCJxZWrIdzYuOw==",
             "cpu": [
                 "arm64"
             ],
@@ -5374,9 +5514,9 @@
             ]
         },
         "node_modules/@rollup/rollup-freebsd-x64": {
-            "version": "4.62.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.4.tgz",
-            "integrity": "sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==",
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.63.1.tgz",
+            "integrity": "sha512-mRJlqSRulVzcKq/LKA6ICSIc3K/l4fzlVn/gePn2nXIHy8seRi5z/eeRE0d/XMBxcMldiXtQTSpRj0tkkC3g8Q==",
             "cpu": [
                 "x64"
             ],
@@ -5387,9 +5527,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-            "version": "4.62.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.4.tgz",
-            "integrity": "sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==",
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.63.1.tgz",
+            "integrity": "sha512-YDUNvVM85TI3g/1OpnqKP1h4NeW/j64DfWMf+G3M809xNk1bJSnpFp4sh83NpmVE5DXnkh8ULor4LTVZKoYLHw==",
             "cpu": [
                 "arm"
             ],
@@ -5403,9 +5543,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-            "version": "4.62.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.4.tgz",
-            "integrity": "sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==",
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.63.1.tgz",
+            "integrity": "sha512-7Mcn71p9ZuQFAj+h+dhQXy/yeLePRS2yKRnmW1DijA9thKO5qap0GNOIQK4yQ6iP3SU0Mrb/yWo8h8vgRba8lw==",
             "cpu": [
                 "arm"
             ],
@@ -5419,9 +5559,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-gnu": {
-            "version": "4.62.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.4.tgz",
-            "integrity": "sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==",
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.63.1.tgz",
+            "integrity": "sha512-4YiLQTX6U4CSl0L9cluep9A9W6UmTfqBDc2/CH6wlu54pl4E7Jn3cOD8oxzvBDEGk/JMKgJ47C8g+radF7mwvg==",
             "cpu": [
                 "arm64"
             ],
@@ -5435,9 +5575,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-musl": {
-            "version": "4.62.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.4.tgz",
-            "integrity": "sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==",
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.63.1.tgz",
+            "integrity": "sha512-2ra8F7w8OquwZN9z2/fKFnli69wa8PLwaVzRMIPGb13ByMJwC28Fbp8YcVGoUhlYMTt7j5j9bNgpysrN2UM+vw==",
             "cpu": [
                 "arm64"
             ],
@@ -5451,9 +5591,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-loong64-gnu": {
-            "version": "4.62.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.4.tgz",
-            "integrity": "sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==",
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.63.1.tgz",
+            "integrity": "sha512-Sy20ncyhjmBP0Ml+UvQbimjlk6VFgjW5uNP+qqwHB00mTE8Bl2C1TuHTlRwK2YoXeZbee5lP2XevBWVkAQAtSQ==",
             "cpu": [
                 "loong64"
             ],
@@ -5467,9 +5607,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-loong64-musl": {
-            "version": "4.62.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.4.tgz",
-            "integrity": "sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==",
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.63.1.tgz",
+            "integrity": "sha512-noITLp8oNjYliPnGWmLyelIHwULGqbHloQHGw1rtxbWhTuWooRpnZarZQJ1y9EUC4szuCusCc+HEpUtxpIwYvA==",
             "cpu": [
                 "loong64"
             ],
@@ -5483,9 +5623,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-            "version": "4.62.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.4.tgz",
-            "integrity": "sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==",
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.63.1.tgz",
+            "integrity": "sha512-hlxxXd+F1mWiAcaFR7Sv9ZQT6m6UfI8+Vy/kFJzztq2pDMU/0wZ9sish0iszNZvsQDo8Gc0i5yuFEOz5dDf6fA==",
             "cpu": [
                 "ppc64"
             ],
@@ -5499,9 +5639,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-ppc64-musl": {
-            "version": "4.62.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.4.tgz",
-            "integrity": "sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==",
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.63.1.tgz",
+            "integrity": "sha512-EF7OpqQTQ/BvGqLzUi4rEHuagCV9MugAUXSHemwPW5vxZ75RR+jxO/2j95Ph2dalMpFHSVECjRoioHZgA9zOYA==",
             "cpu": [
                 "ppc64"
             ],
@@ -5515,9 +5655,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-            "version": "4.62.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.4.tgz",
-            "integrity": "sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==",
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.63.1.tgz",
+            "integrity": "sha512-wQO3JesW9PRkwlabQ27y7sPfVOOTLRG73I4F2UYHG5PXun3J9U3y+b7ezVKSYbsvSKGQ1k1cq8Qlun4C9kLt3w==",
             "cpu": [
                 "riscv64"
             ],
@@ -5531,9 +5671,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-musl": {
-            "version": "4.62.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.4.tgz",
-            "integrity": "sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==",
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.63.1.tgz",
+            "integrity": "sha512-ouAGwhO6wHRXdnOVCOsB0tRFkA7nhNB2Nwax6oECXN0YiN8EYUTBAOudADOB1PI+yDL61TeNx/u7MVCzksNbkQ==",
             "cpu": [
                 "riscv64"
             ],
@@ -5547,9 +5687,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-s390x-gnu": {
-            "version": "4.62.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.4.tgz",
-            "integrity": "sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==",
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.63.1.tgz",
+            "integrity": "sha512-q2R38Sn+1J8RxhfJ+T54wSWmyKXWec+9jgDfqO2AtArEqHO5R2aeayp5H5OYLr5UYDVGsVaZPEFUooMhYCdz5A==",
             "cpu": [
                 "s390x"
             ],
@@ -5563,9 +5703,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-gnu": {
-            "version": "4.62.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.4.tgz",
-            "integrity": "sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==",
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.63.1.tgz",
+            "integrity": "sha512-gfI5T24WLLuFfSKw7Go/zDXjAAV0fny0swTaDv+WjK7vqcw4cRhFfdsyKL1n+ukI+ooBxn3bVQnyrn06WpI50w==",
             "cpu": [
                 "x64"
             ],
@@ -5579,9 +5719,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-musl": {
-            "version": "4.62.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.4.tgz",
-            "integrity": "sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==",
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.63.1.tgz",
+            "integrity": "sha512-4h6XqthmB4Hspji84wvgk+ElodTsGj+dbZqHJHHtKxj4mYq0ANSEEPX9ys3moJueqsRjwpaJYH7874Itwnj2ow==",
             "cpu": [
                 "x64"
             ],
@@ -5595,9 +5735,9 @@
             ]
         },
         "node_modules/@rollup/rollup-openbsd-x64": {
-            "version": "4.62.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.4.tgz",
-            "integrity": "sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==",
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.63.1.tgz",
+            "integrity": "sha512-dlfCOa87o1VAYegLQ9EKilx2JCeRofiyPGhTCmqnuXZ6bMPiycO1rq1+sKoulAp7pGLIsTIw+1x5R+zgh5LhhA==",
             "cpu": [
                 "x64"
             ],
@@ -5608,9 +5748,9 @@
             ]
         },
         "node_modules/@rollup/rollup-openharmony-arm64": {
-            "version": "4.62.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.4.tgz",
-            "integrity": "sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==",
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.63.1.tgz",
+            "integrity": "sha512-cjkLbOlfcm3QGhMM1J5zaZjsw1GggbN6rw9UTSSRrPrR1KkcXnN7Uq9rPw34xImQ9VOY9GN+6u2Zj80B9ptkcw==",
             "cpu": [
                 "arm64"
             ],
@@ -5621,9 +5761,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-arm64-msvc": {
-            "version": "4.62.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.4.tgz",
-            "integrity": "sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==",
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.63.1.tgz",
+            "integrity": "sha512-Li1KdUnWGE4N3e1F/B4RTB1ms+nG4WBgjByO46pkeBVX/2UBsY53xf5vK9WygVmnH3RwncIST7lkSdLSY6P9lg==",
             "cpu": [
                 "arm64"
             ],
@@ -5634,9 +5774,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-ia32-msvc": {
-            "version": "4.62.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.4.tgz",
-            "integrity": "sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==",
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.63.1.tgz",
+            "integrity": "sha512-t4ZYOSoLTgwhuFMrmTMLx/+i1DQVK7HYqMc6kY46EApwi8X0nIVphzdNoThU3xt6n+N5urG1/gxBdCaKDLavfg==",
             "cpu": [
                 "ia32"
             ],
@@ -5647,9 +5787,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-x64-gnu": {
-            "version": "4.62.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.4.tgz",
-            "integrity": "sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==",
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.63.1.tgz",
+            "integrity": "sha512-RgroPfMmKlD1RzSDxvwgcPiy2HNQKoYV7OmwIXDsk73uKW5t6B/V8KIy27SMv/FNXFo/oSBtWc9J0X7t91ezZg==",
             "cpu": [
                 "x64"
             ],
@@ -5660,9 +5800,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-x64-msvc": {
-            "version": "4.62.4",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.4.tgz",
-            "integrity": "sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==",
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.63.1.tgz",
+            "integrity": "sha512-at8QVep6S3h5Y6gSbdGU06bRY5WJkf6WUduM9YtvYMbYhB1MOFfUgc6kehitQXzOtMSaT70q7f9ydPhpqu821w==",
             "cpu": [
                 "x64"
             ],
@@ -6127,66 +6267,6 @@
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
-            "version": "1.11.1",
-            "inBundle": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "@emnapi/wasi-threads": "1.2.2",
-                "tslib": "^2.4.0"
-            }
-        },
-        "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
-            "version": "1.11.1",
-            "inBundle": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "tslib": "^2.4.0"
-            }
-        },
-        "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
-            "version": "1.2.2",
-            "inBundle": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "tslib": "^2.4.0"
-            }
-        },
-        "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
-            "version": "1.1.4",
-            "inBundle": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "@tybys/wasm-util": "^0.10.1"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/Brooooooklyn"
-            },
-            "peerDependencies": {
-                "@emnapi/core": "^1.7.1",
-                "@emnapi/runtime": "^1.7.1"
-            }
-        },
-        "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
-            "version": "0.10.2",
-            "inBundle": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "tslib": "^2.4.0"
-            }
-        },
-        "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
-            "version": "2.8.1",
-            "inBundle": true,
-            "license": "0BSD",
-            "optional": true
-        },
         "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
             "version": "4.3.3",
             "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.3.tgz",
@@ -6247,31 +6327,39 @@
             }
         },
         "node_modules/@takumi-rs/core": {
-            "version": "1.8.7",
-            "resolved": "https://registry.npmjs.org/@takumi-rs/core/-/core-1.8.7.tgz",
-            "integrity": "sha512-Ia8I3vg0VAQPnzHiYRrd18UgZbIj3X0zMwWMjuTm3yb2TBH1988lPwnnlf+eAfYMwZrutNiXLLtgEnkzsm2gMw==",
+            "version": "2.13.7",
+            "resolved": "https://registry.npmjs.org/@takumi-rs/core/-/core-2.13.7.tgz",
+            "integrity": "sha512-FBkglt8kGBZwT2CHr+kppN+FH72Oy8gLIZz1BIbD9vNcocLrvtLsh1Y0nB18mOPmaROKGUVUXLPnIuWo49CRng==",
             "license": "(MIT OR Apache-2.0)",
             "dependencies": {
-                "@takumi-rs/helpers": "1.8.7"
+                "@takumi-rs/helpers": "2.13.7"
             },
             "engines": {
-                "node": ">= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0"
+                "node": ">=18"
             },
             "optionalDependencies": {
-                "@takumi-rs/core-darwin-arm64": "1.8.7",
-                "@takumi-rs/core-darwin-x64": "1.8.7",
-                "@takumi-rs/core-linux-arm64-gnu": "1.8.7",
-                "@takumi-rs/core-linux-arm64-musl": "1.8.7",
-                "@takumi-rs/core-linux-x64-gnu": "1.8.7",
-                "@takumi-rs/core-linux-x64-musl": "1.8.7",
-                "@takumi-rs/core-win32-arm64-msvc": "1.8.7",
-                "@takumi-rs/core-win32-x64-msvc": "1.8.7"
+                "@takumi-rs/core-darwin-arm64": "2.13.7",
+                "@takumi-rs/core-darwin-x64": "2.13.7",
+                "@takumi-rs/core-linux-arm64-gnu": "2.13.7",
+                "@takumi-rs/core-linux-arm64-musl": "2.13.7",
+                "@takumi-rs/core-linux-x64-gnu": "2.13.7",
+                "@takumi-rs/core-linux-x64-musl": "2.13.7",
+                "@takumi-rs/core-win32-arm64-msvc": "2.13.7",
+                "@takumi-rs/core-win32-x64-msvc": "2.13.7"
+            },
+            "peerDependencies": {
+                "csstype": "*"
+            },
+            "peerDependenciesMeta": {
+                "csstype": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@takumi-rs/core-darwin-arm64": {
-            "version": "1.8.7",
-            "resolved": "https://registry.npmjs.org/@takumi-rs/core-darwin-arm64/-/core-darwin-arm64-1.8.7.tgz",
-            "integrity": "sha512-an8vc2B/Qf9vo3uwDmJ6WKazpMBpDruRy/kXr+x98GfIkzMHDEUy+9EgNfUYxprtZo49cJruXrVwzxsqqW+1tA==",
+            "version": "2.13.7",
+            "resolved": "https://registry.npmjs.org/@takumi-rs/core-darwin-arm64/-/core-darwin-arm64-2.13.7.tgz",
+            "integrity": "sha512-Jbe1ik4bcVOOHDpa5RCjm5fe+LfJjjyebvvPBMekhEKXg6hlTbIEFmhr/GCxMOKUfaNsvb4amZ/bVCo0NDSCjA==",
             "cpu": [
                 "arm64"
             ],
@@ -6281,13 +6369,13 @@
                 "darwin"
             ],
             "engines": {
-                "node": ">= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0"
+                "node": ">=18"
             }
         },
         "node_modules/@takumi-rs/core-darwin-x64": {
-            "version": "1.8.7",
-            "resolved": "https://registry.npmjs.org/@takumi-rs/core-darwin-x64/-/core-darwin-x64-1.8.7.tgz",
-            "integrity": "sha512-q0xQxmb4y4EwYK3ILMBvWvqLGX8gxsqcEas0zOwNbPnxBLTQFF8KVH4jXaKXLUFwj020lu8nsf1BNvLIkJMo3Q==",
+            "version": "2.13.7",
+            "resolved": "https://registry.npmjs.org/@takumi-rs/core-darwin-x64/-/core-darwin-x64-2.13.7.tgz",
+            "integrity": "sha512-PvmSmhjbSosM3XaHZ9VhFm1x7Xc9oZ5GqXlskiwZblKIi5S4EI43buhUd28xzcBlKkB/vC3c15Cj417XjnUk4g==",
             "cpu": [
                 "x64"
             ],
@@ -6297,13 +6385,13 @@
                 "darwin"
             ],
             "engines": {
-                "node": ">= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0"
+                "node": ">=18"
             }
         },
         "node_modules/@takumi-rs/core-linux-arm64-gnu": {
-            "version": "1.8.7",
-            "resolved": "https://registry.npmjs.org/@takumi-rs/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.8.7.tgz",
-            "integrity": "sha512-uZ6l792M4Mc06XG+m+8RarTgdR5o1ZLjncULKUEPAw3nBKhRbJ50Re3aLM4n4+p25iOj1oL9QwEZRcaJn8u/Ag==",
+            "version": "2.13.7",
+            "resolved": "https://registry.npmjs.org/@takumi-rs/core-linux-arm64-gnu/-/core-linux-arm64-gnu-2.13.7.tgz",
+            "integrity": "sha512-TGvDidIF3dtb7TMoJRF+0BET/v6eAuQxV8AXo/57GqO3TM9wjLt3AbkrFkzxSsaIRXlBQxCfb+GsS0YdGnpo4w==",
             "cpu": [
                 "arm64"
             ],
@@ -6316,13 +6404,13 @@
                 "linux"
             ],
             "engines": {
-                "node": ">= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0"
+                "node": ">=18"
             }
         },
         "node_modules/@takumi-rs/core-linux-arm64-musl": {
-            "version": "1.8.7",
-            "resolved": "https://registry.npmjs.org/@takumi-rs/core-linux-arm64-musl/-/core-linux-arm64-musl-1.8.7.tgz",
-            "integrity": "sha512-akVy80ztI2as/b0n0EVCfHNKhibp+Od4ioP49PtX2rQMi6KDtqv3aoCIjaBls8oxzv+4x77/2U9fsWIO2XZQjg==",
+            "version": "2.13.7",
+            "resolved": "https://registry.npmjs.org/@takumi-rs/core-linux-arm64-musl/-/core-linux-arm64-musl-2.13.7.tgz",
+            "integrity": "sha512-CL92+JeFbqlPfWI2SSQqLtcjWpxEsPYQ+wNhaqUWLnlTMfZfj+Fl3ERFLbmK+lYnGs7bzpPXLisd3GJQ37rTYw==",
             "cpu": [
                 "arm64"
             ],
@@ -6335,13 +6423,13 @@
                 "linux"
             ],
             "engines": {
-                "node": ">= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0"
+                "node": ">=18"
             }
         },
         "node_modules/@takumi-rs/core-linux-x64-gnu": {
-            "version": "1.8.7",
-            "resolved": "https://registry.npmjs.org/@takumi-rs/core-linux-x64-gnu/-/core-linux-x64-gnu-1.8.7.tgz",
-            "integrity": "sha512-SV1YesGs/HfC1CMpSF5SqS6KbL4hDLvD2m54JcfB+X/0xatmo/CS2XleqoIXhSmR+95X8Of5g2vg1a4TAdpcug==",
+            "version": "2.13.7",
+            "resolved": "https://registry.npmjs.org/@takumi-rs/core-linux-x64-gnu/-/core-linux-x64-gnu-2.13.7.tgz",
+            "integrity": "sha512-ZxoapyUDlInik93WIA9+Sk/ByOb3QGO7GaL9PA7OOdIlK5ovK9v9q88tZb1cvfxtIVzdE9HPBUhb5quNMcuXWg==",
             "cpu": [
                 "x64"
             ],
@@ -6354,13 +6442,13 @@
                 "linux"
             ],
             "engines": {
-                "node": ">= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0"
+                "node": ">=18"
             }
         },
         "node_modules/@takumi-rs/core-linux-x64-musl": {
-            "version": "1.8.7",
-            "resolved": "https://registry.npmjs.org/@takumi-rs/core-linux-x64-musl/-/core-linux-x64-musl-1.8.7.tgz",
-            "integrity": "sha512-zprYQ/ivPDmYX4tFaONiAzoDJNTANA3kqfIe7SMHZ2YhkfEhYnr3PE3XtBytgB4W/VlTc9WQLyD77SKwPnPuFw==",
+            "version": "2.13.7",
+            "resolved": "https://registry.npmjs.org/@takumi-rs/core-linux-x64-musl/-/core-linux-x64-musl-2.13.7.tgz",
+            "integrity": "sha512-OqoVTd7mrlIwjKYYFizUwz+3zpnVsbrpLFPXFC+BmUxdFYNZwKa0R+Pk56EslyBZS3CuBy+RnBusHCvNC7+09g==",
             "cpu": [
                 "x64"
             ],
@@ -6373,13 +6461,13 @@
                 "linux"
             ],
             "engines": {
-                "node": ">= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0"
+                "node": ">=18"
             }
         },
         "node_modules/@takumi-rs/core-win32-arm64-msvc": {
-            "version": "1.8.7",
-            "resolved": "https://registry.npmjs.org/@takumi-rs/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.8.7.tgz",
-            "integrity": "sha512-2S5YcgIj/c0E3sLzWDcxzlXoPvEjR2xC1v7yODe0CvimlRx95Df6rJ9idTS6E1KNUjDaTfqxTr8Ud4gWqYrrPg==",
+            "version": "2.13.7",
+            "resolved": "https://registry.npmjs.org/@takumi-rs/core-win32-arm64-msvc/-/core-win32-arm64-msvc-2.13.7.tgz",
+            "integrity": "sha512-evSyi/y3uV03U+PJfLeG2V3aRsmmWJ6elrFpkLtHebWwi49kXazTL5TYsCkPj5hA4i+rNs6z/t/BygLj1Krp8Q==",
             "cpu": [
                 "arm64"
             ],
@@ -6389,13 +6477,13 @@
                 "win32"
             ],
             "engines": {
-                "node": ">= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0"
+                "node": ">=18"
             }
         },
         "node_modules/@takumi-rs/core-win32-x64-msvc": {
-            "version": "1.8.7",
-            "resolved": "https://registry.npmjs.org/@takumi-rs/core-win32-x64-msvc/-/core-win32-x64-msvc-1.8.7.tgz",
-            "integrity": "sha512-sooiM6fL0JN597ciNAFVp9F7YxCW+8hXpwu/7wRMRo0TGQ/KMi1Y94tf1FUu2csCHN0pgy9a3y09y8+qnw3FTw==",
+            "version": "2.13.7",
+            "resolved": "https://registry.npmjs.org/@takumi-rs/core-win32-x64-msvc/-/core-win32-x64-msvc-2.13.7.tgz",
+            "integrity": "sha512-GawtljFxuJemQynlF5wryxtSLv18XNuKSjMt52xf66WMaBKt4eN6/b7yIZp9QqKPof8ip8uqFOt7fWVSUN+gHQ==",
             "cpu": [
                 "x64"
             ],
@@ -6405,23 +6493,26 @@
                 "win32"
             ],
             "engines": {
-                "node": ">= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0"
+                "node": ">=18"
             }
         },
         "node_modules/@takumi-rs/helpers": {
-            "version": "1.8.7",
-            "resolved": "https://registry.npmjs.org/@takumi-rs/helpers/-/helpers-1.8.7.tgz",
-            "integrity": "sha512-5dSR9W8msQ7Asp4TCvUUB9Bt8yLgIc2ASjWtEG4Jn9xSuAVJLWFZ21Xl8HShW5GE6SV5aCCM9BL0NA9YuBWIJw==",
+            "version": "2.13.7",
+            "resolved": "https://registry.npmjs.org/@takumi-rs/helpers/-/helpers-2.13.7.tgz",
+            "integrity": "sha512-6AKk/ixuvoCEZD9/LPAz3kxTcwWHeZh15quhHIHYiVxFRl4x2LyKN8j6eZngiepYYsORXAuJ5YlTGA7uIRfeMQ==",
             "license": "(MIT OR Apache-2.0)",
+            "engines": {
+                "node": ">=18"
+            },
             "peerDependencies": {
-                "react": "^19.2.5",
-                "react-dom": "^18.0.0 || ^19.0.0"
+                "preact": "^10.0.0",
+                "react": "^18.0.0 || ^19.0.0"
             },
             "peerDependenciesMeta": {
-                "react": {
+                "preact": {
                     "optional": true
                 },
-                "react-dom": {
+                "react": {
                     "optional": true
                 }
             }
@@ -6485,49 +6576,49 @@
             }
         },
         "node_modules/@tiptap/core": {
-            "version": "3.30.5",
-            "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.30.5.tgz",
-            "integrity": "sha512-3O7N0FyKIfuLV+xrdWyDM3V5eUY/q2CgLjhhMwOAbM1Pu7VPp9VP+TpEYOdH8aRyB+h1vj5hX5A747D8ZrPfHA==",
+            "version": "3.31.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.31.3.tgz",
+            "integrity": "sha512-Cz50pvciQrxdSxgTkHOVz0uD0Yl/8Xt0QatGD6ILm47jW8EzyHR9RkUGs/D5IqzXKuVPntfw1ttaT926vXfiRg==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/pm": "3.30.5"
+                "@tiptap/pm": "3.31.3"
             }
         },
         "node_modules/@tiptap/extension-blockquote": {
-            "version": "3.30.5",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-blockquote/-/extension-blockquote-3.30.5.tgz",
-            "integrity": "sha512-8pf1ZDrl6XlVPUee/2YlWZPFSF7yqsJEX6WLW41x06MT1dapG3Qudcns0znj6kYsX8JXTJ+Mhegy4z19bvTtRg==",
+            "version": "3.31.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-blockquote/-/extension-blockquote-3.31.3.tgz",
+            "integrity": "sha512-fyY2XMbyDDDfOTQ1Qdrnqa1qwC9DWE4n7AfE0EKQI0G8MfLV8RaDlLDcOZDJ9JbMPY7/Gx7EjyK4NKxSW9n2hQ==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "3.30.5",
-                "@tiptap/pm": "3.30.5"
+                "@tiptap/core": "3.31.3",
+                "@tiptap/pm": "3.31.3"
             }
         },
         "node_modules/@tiptap/extension-bold": {
-            "version": "3.30.5",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-bold/-/extension-bold-3.30.5.tgz",
-            "integrity": "sha512-MLZS+s/BJiJbv2C2M3G4FQGn43kPwYUUr2TiW3afSn+dRkEZlDxx5CwZYbe1PEt2+VX/SIifn945Oqr3s0axSA==",
+            "version": "3.31.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-bold/-/extension-bold-3.31.3.tgz",
+            "integrity": "sha512-dIuYhKk8TitKU/FeDpoTeWZhU42YgDN5npgWNjAmMmRktPdoxnH3/wGSiwXlqZgJWjehN7kPWDePWpJeAImGpQ==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "3.30.5"
+                "@tiptap/core": "3.31.3"
             }
         },
         "node_modules/@tiptap/extension-bubble-menu": {
-            "version": "3.30.5",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-bubble-menu/-/extension-bubble-menu-3.30.5.tgz",
-            "integrity": "sha512-redcmBInVwmipjF/WEVcNwCUJgJygUv8leidfRb/jBSAwx7GgnQWPr2HVQDk9zeTt3ykWld2NRdrk94Crjymow==",
+            "version": "3.31.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-bubble-menu/-/extension-bubble-menu-3.31.3.tgz",
+            "integrity": "sha512-EV6ZnwKc++2OM/OcD54n8s1B7C9LP7GKAtdEPwu0t3BYJf3sG8Ueoinf7SgGPO9oMPg96GneOkDNm1urMV167g==",
             "license": "MIT",
             "dependencies": {
                 "@floating-ui/dom": "^1.0.0"
@@ -6537,83 +6628,83 @@
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "3.30.5",
-                "@tiptap/pm": "3.30.5"
+                "@tiptap/core": "3.31.3",
+                "@tiptap/pm": "3.31.3"
             }
         },
         "node_modules/@tiptap/extension-bullet-list": {
-            "version": "3.30.5",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-bullet-list/-/extension-bullet-list-3.30.5.tgz",
-            "integrity": "sha512-66OGw4suO0Gr/4QAEiSvVi0eSvEqStvu1moHUSvUlwvEqnuB0ME2w9HuRogPElzWdrYLzbBA47mlCi9Veva0ew==",
+            "version": "3.31.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-bullet-list/-/extension-bullet-list-3.31.3.tgz",
+            "integrity": "sha512-qEyyoPapPef4LO8XKaN83bxtaNzkJ4kFn/IxLnEKd4BJ3Mvi4MH2yJYlyDqwFnMoev4pMA1zBHRAt/C0THRmZw==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/extension-list": "3.30.5"
+                "@tiptap/extension-list": "3.31.3"
             }
         },
         "node_modules/@tiptap/extension-code": {
-            "version": "3.30.5",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-code/-/extension-code-3.30.5.tgz",
-            "integrity": "sha512-0dCt8eBo4sMtw+LjUu+0GF0JrTlREROdWoy8TM5kFPxJ5ZU2LKDiROXDPwXStaaoFFR/aStLH9xSpdz7cHUiUA==",
+            "version": "3.31.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-code/-/extension-code-3.31.3.tgz",
+            "integrity": "sha512-SzxOqchrD2AcN3uT67PjKmRFEMOU3vNNiwNaamZJUbZrI6Hmy+bvdHJrc3jrIddyyCrAtsnAfRI0cmorW1jGfg==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "3.30.5"
+                "@tiptap/core": "3.31.3"
             }
         },
         "node_modules/@tiptap/extension-code-block": {
-            "version": "3.30.5",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-3.30.5.tgz",
-            "integrity": "sha512-SvkNoOio2xBy9AtSMyFKMp88MTUvyIXsGCnuz71INV2wHdH4VfRPoQLT6e077LpTCa9w6LHyTKtbZA4HYOp7wg==",
+            "version": "3.31.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-3.31.3.tgz",
+            "integrity": "sha512-nvknt4FhyJQjYcvxptmeUlFsIAc8ibua3E5BN4Pim374/9RWepH4cdE9X0/qUTtguHElLx0iKtSIY3rW2qGTFA==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "3.30.5",
-                "@tiptap/pm": "3.30.5"
+                "@tiptap/core": "3.31.3",
+                "@tiptap/pm": "3.31.3"
             }
         },
         "node_modules/@tiptap/extension-collaboration": {
-            "version": "3.30.5",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-collaboration/-/extension-collaboration-3.30.5.tgz",
-            "integrity": "sha512-LIw2JCPhAI7mWEfaPzct2WYAmSMuv4QPRQqX6AGtg6EcqLUj2N39ds6kBg5jgC7g8vGUNs8/lj5C/9SW0YrDyw==",
+            "version": "3.31.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-collaboration/-/extension-collaboration-3.31.3.tgz",
+            "integrity": "sha512-JAwOXjeeDYghrPcK57dtvxwn06zcz50mxSSk4PaSdLxM8tkw8+udx+51ewqKKd3WlFof4zyMwUEbO/DGaUdEvw==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "3.30.5",
-                "@tiptap/pm": "3.30.5",
+                "@tiptap/core": "3.31.3",
+                "@tiptap/pm": "3.31.3",
                 "@tiptap/y-tiptap": "^3.0.7",
                 "yjs": "^13"
             }
         },
         "node_modules/@tiptap/extension-document": {
-            "version": "3.30.5",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-3.30.5.tgz",
-            "integrity": "sha512-4mKoD3bBr5W2AQ2Y/7amOqcVw0eqJbUwRtwvxypeo5Hi0PB9O5Ev8P05c3EUTo10bllqdKYXGeCU5AcgdQsHWQ==",
+            "version": "3.31.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-3.31.3.tgz",
+            "integrity": "sha512-EexgmqnyDNyGlISxo7SMrp5MygpJYmqD+0cY5jB6L1U6L4CpKKRWUt8OO1sWzEHDE1+TTvwt+WIFoIWAziOtEA==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "3.30.5"
+                "@tiptap/core": "3.31.3"
             }
         },
         "node_modules/@tiptap/extension-drag-handle": {
-            "version": "3.30.5",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-drag-handle/-/extension-drag-handle-3.30.5.tgz",
-            "integrity": "sha512-gCqZK31AkJ5qdvYcE/5zOsThKdHGNv4bNQHq/jAVikWOjsfF/3jE2XDc7SF+CTCgXZK4ssUg2H29RIhHVzESyA==",
+            "version": "3.31.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-drag-handle/-/extension-drag-handle-3.31.3.tgz",
+            "integrity": "sha512-2WOcg5wbGTJNlzLzdaw0IQgbzObjs2k55ZYZito3WRsMKZ3BPJK8pj5GOYKnJ7dm6VlKrpP7WmNq3HGpxe5GOA==",
             "license": "MIT",
             "dependencies": {
                 "@floating-ui/dom": "^1.6.13"
@@ -6623,46 +6714,46 @@
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "3.30.5",
-                "@tiptap/extension-collaboration": "3.30.5",
-                "@tiptap/extension-node-range": "3.30.5",
-                "@tiptap/pm": "3.30.5",
+                "@tiptap/core": "3.31.3",
+                "@tiptap/extension-collaboration": "3.31.3",
+                "@tiptap/extension-node-range": "3.31.3",
+                "@tiptap/pm": "3.31.3",
                 "@tiptap/y-tiptap": "^3.0.7"
             }
         },
         "node_modules/@tiptap/extension-drag-handle-vue-3": {
-            "version": "3.30.5",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-drag-handle-vue-3/-/extension-drag-handle-vue-3-3.30.5.tgz",
-            "integrity": "sha512-+cOFesVWeyHflOR85GEmHt/lijUJfrjRyqa3yl4mmtLOWfWYKYCNXd0SxIDOvQYH0xMzZ3uAPUgWyO5cZMDemg==",
+            "version": "3.31.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-drag-handle-vue-3/-/extension-drag-handle-vue-3-3.31.3.tgz",
+            "integrity": "sha512-k/8j17rOgSvbR45fJ/0rzcXfWqLl55RVMrytHHb6o7Bvc4qDDIkk7FIGqqcaCBxfZBd7dfo21FebTP1SUeEAVw==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/extension-drag-handle": "3.30.5",
-                "@tiptap/pm": "3.30.5",
-                "@tiptap/vue-3": "3.30.5",
+                "@tiptap/extension-drag-handle": "3.31.3",
+                "@tiptap/pm": "3.31.3",
+                "@tiptap/vue-3": "3.31.3",
                 "vue": "^3.0.0"
             }
         },
         "node_modules/@tiptap/extension-dropcursor": {
-            "version": "3.30.5",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-dropcursor/-/extension-dropcursor-3.30.5.tgz",
-            "integrity": "sha512-gJxn9PMUee8zazQBYqbOZiI7zTFXPVJ15AzTnLfUu4eDtPieMwtpgcjhCt4bZlp37drLm+Li76wWLirb7iLxsw==",
+            "version": "3.31.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-dropcursor/-/extension-dropcursor-3.31.3.tgz",
+            "integrity": "sha512-NWomSfu5CSC7VacnMSDzKT8qm66SzMfZwVPEtwY5bPpRTJgTiT1rNK0neDrrzfMN27MfylGyKWWf7Q5Qf8w/fg==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/extensions": "3.30.5"
+                "@tiptap/extensions": "3.31.3"
             }
         },
         "node_modules/@tiptap/extension-floating-menu": {
-            "version": "3.30.5",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-floating-menu/-/extension-floating-menu-3.30.5.tgz",
-            "integrity": "sha512-gTjGPWUpGn8IoW533TciZJZC/81LmBgU7zee+aRMRF3ix3K2z1pJjl6knDvrRQA6Kom+yWFaiueqGNXkrk38XQ==",
+            "version": "3.31.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-floating-menu/-/extension-floating-menu-3.31.3.tgz",
+            "integrity": "sha512-rd4VJ9PGSP9Eop8ZTEwaLZcMzMXLuJKe3hUNf58rq+zANpwM+9fI+vB7g9MAc3eXwUNDxNDVACFIL2oeBqpQ3A==",
             "license": "MIT",
             "funding": {
                 "type": "github",
@@ -6670,93 +6761,93 @@
             },
             "peerDependencies": {
                 "@floating-ui/dom": "^1.0.0",
-                "@tiptap/core": "3.30.5",
-                "@tiptap/pm": "3.30.5"
+                "@tiptap/core": "3.31.3",
+                "@tiptap/pm": "3.31.3"
             }
         },
         "node_modules/@tiptap/extension-gapcursor": {
-            "version": "3.30.5",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-gapcursor/-/extension-gapcursor-3.30.5.tgz",
-            "integrity": "sha512-h3m2ZA1XXLAfdHwdtG0MZnf0KWbNyP8xTI3RUlTDR5apmKmYVBaeocOJwTcFFZ92gPKqxYKyhteZqYtHOCZGJA==",
+            "version": "3.31.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-gapcursor/-/extension-gapcursor-3.31.3.tgz",
+            "integrity": "sha512-EBXKb1FrVStsNYCcRGtd9jmzveCvR+eqgg1rVqoONrqFK6U7bga6LN+1dMKroP1kliDVgveYkP3vRYxqw+rFqg==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/extensions": "3.30.5"
+                "@tiptap/extensions": "3.31.3"
             }
         },
         "node_modules/@tiptap/extension-hard-break": {
-            "version": "3.30.5",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-hard-break/-/extension-hard-break-3.30.5.tgz",
-            "integrity": "sha512-PcL4Z8l/DlauwZUJg0jf6SXKk6/YOXJtd8yYzqHrmCLRoY4kAa7+TxUhc/lWhuitUiOZ8+nB8V/NNM+WR6mRaw==",
+            "version": "3.31.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-hard-break/-/extension-hard-break-3.31.3.tgz",
+            "integrity": "sha512-QAdCvNO4+yW9ATwsrej11NTkDYFqPLIEQr3ARNrKOK1qaiS7A0fia2SEukb/hrkP3A6mbozhoQt2r2RGUf/DpQ==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "3.30.5"
+                "@tiptap/core": "3.31.3"
             }
         },
         "node_modules/@tiptap/extension-heading": {
-            "version": "3.30.5",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-heading/-/extension-heading-3.30.5.tgz",
-            "integrity": "sha512-x7e7+p1bWXvwz6vqONPP1SVB73V0gZP7LIDL/5KMnxWLjahMTabgVPgjV30kz7GsOEgUYtEf7eCyGVGNNWL5Dg==",
+            "version": "3.31.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-heading/-/extension-heading-3.31.3.tgz",
+            "integrity": "sha512-rk5VHMAeQcg06SLauN6EGdD2jc0O2qY8QkZYPd0LxNvLblw2BxBx+lxUQSYwLAT9Ie5914gKIK2YbRyO2Ts3ig==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "3.30.5"
+                "@tiptap/core": "3.31.3"
             }
         },
         "node_modules/@tiptap/extension-horizontal-rule": {
-            "version": "3.30.5",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-horizontal-rule/-/extension-horizontal-rule-3.30.5.tgz",
-            "integrity": "sha512-s5t2xM6wPYRJl2cqYplc7Ze8m8xddk4DP2v0aLFcUuD100D1B5eJbxsiwLK6wBAzNwiuVjd486RnmUpcswaXhQ==",
+            "version": "3.31.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-horizontal-rule/-/extension-horizontal-rule-3.31.3.tgz",
+            "integrity": "sha512-YnHGy2KShRwvCseAmmxl9VP7R0qaj8QMp3DA6DJWZqp7r5gLGvDkAqhedxqqefqsE4Y43hjkBdjtB9Ce78LkIw==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "3.30.5",
-                "@tiptap/pm": "3.30.5"
+                "@tiptap/core": "3.31.3",
+                "@tiptap/pm": "3.31.3"
             }
         },
         "node_modules/@tiptap/extension-image": {
-            "version": "3.30.5",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-image/-/extension-image-3.30.5.tgz",
-            "integrity": "sha512-fETBsbSTaf5MLCGZaffHRRAFYUHeDIeITbnm7Q5Il+/LlX7PEiBZGKVyD/M3bIMpxhkyB0UlryIYGhC5LjN1Aw==",
+            "version": "3.31.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-image/-/extension-image-3.31.3.tgz",
+            "integrity": "sha512-wWNG9BOtx2Cg4vwxPVGDIJ5DGX+ETkldeoaFJLB1NXUL4OPUiVTf8cHZ+hdYgJWP704BEB7jQgjlpvdi6VigTg==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "3.30.5"
+                "@tiptap/core": "3.31.3"
             }
         },
         "node_modules/@tiptap/extension-italic": {
-            "version": "3.30.5",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-italic/-/extension-italic-3.30.5.tgz",
-            "integrity": "sha512-Fu9EuSRlHQNGES7UhY4mQod3yUKnWwxsGlPuDJURfwju/Ug04Jz8iRuERZBPcRgLNkwKDmbDsWUZF72RRIL2Uw==",
+            "version": "3.31.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-italic/-/extension-italic-3.31.3.tgz",
+            "integrity": "sha512-ibGvdvAPyfxBMUVNRI43eb9h2/Jka1MRG5GtnGqbcCX/2+Y/y0EOfFrPQPkuYphiWQYyu9+FzPKMB/pjuaLuKQ==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "3.30.5"
+                "@tiptap/core": "3.31.3"
             }
         },
         "node_modules/@tiptap/extension-link": {
-            "version": "3.30.5",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-link/-/extension-link-3.30.5.tgz",
-            "integrity": "sha512-zsQ+q83HpCYOMTNzdjb12dggE7sZMp0aqQJhArdavSTl8hLbVY/u3qJN88t25IEwAKVK0pcTJfWWA2QFl8bjAQ==",
+            "version": "3.31.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-link/-/extension-link-3.31.3.tgz",
+            "integrity": "sha512-986wOQzTL9Zr5lf84LCLpm+YOms8A0K39/8DVoqRfebqcOe0/eq4bnztmAlfabOd+kJY92g3AgZERFUx/w+dcw==",
             "license": "MIT",
             "dependencies": {
                 "linkifyjs": "^4.3.3"
@@ -6766,175 +6857,175 @@
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "3.30.5",
-                "@tiptap/pm": "3.30.5"
+                "@tiptap/core": "3.31.3",
+                "@tiptap/pm": "3.31.3"
             }
         },
         "node_modules/@tiptap/extension-list": {
-            "version": "3.30.5",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.30.5.tgz",
-            "integrity": "sha512-CHThihH+7TA0TfwtmA+eTXP1MAsA/+p011olJHg8Rilj5xA+L+0IFkjhN16JnZkBgSA4MnfEv15UMNfRaNpuVg==",
+            "version": "3.31.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.31.3.tgz",
+            "integrity": "sha512-LoveGnC0FVdCV4jUNBaG1ZA+KWE07+adzV3kGy6uUYFcJEjbVUHTnPDrBOob3IwOSO3sCwIkvQb6EVYeXn/4yg==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "3.30.5",
-                "@tiptap/pm": "3.30.5"
+                "@tiptap/core": "3.31.3",
+                "@tiptap/pm": "3.31.3"
             }
         },
         "node_modules/@tiptap/extension-list-item": {
-            "version": "3.30.5",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-list-item/-/extension-list-item-3.30.5.tgz",
-            "integrity": "sha512-N0fKUyQkPQBvVB48imjfIfdexU9VsAX1RydajYP2xAt+QOJ8KHVmXv1EGTp+v7pGdZMLdls1cSZ2f352vW3aWQ==",
+            "version": "3.31.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-list-item/-/extension-list-item-3.31.3.tgz",
+            "integrity": "sha512-4QlKOriJJMvg95QJTEsy9BUYPBQ6UvJyb8WURRwdUtQUkkqb8h32lg/eyQUv2FzW9IT1AdUyNZfVaxH64kRfQA==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/extension-list": "3.30.5"
+                "@tiptap/extension-list": "3.31.3"
             }
         },
         "node_modules/@tiptap/extension-list-keymap": {
-            "version": "3.30.5",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-list-keymap/-/extension-list-keymap-3.30.5.tgz",
-            "integrity": "sha512-3pLR2yo29uhowaGMbD8v71XpgdNmqotBg1NXlyTMVFzxELj+VjjeLLTqSguR/iWDUbHXNzIsfMEgpRnNMO//8w==",
+            "version": "3.31.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-list-keymap/-/extension-list-keymap-3.31.3.tgz",
+            "integrity": "sha512-If8UOEdDZbPJU6iYTvLtH6DOp2KBy6BKxg9UELL1AevVetGHEF/7lW8hP50Gn1tHMVpPRqmhSzVrJRpEJJgb/Q==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/extension-list": "3.30.5"
+                "@tiptap/extension-list": "3.31.3"
             }
         },
         "node_modules/@tiptap/extension-mention": {
-            "version": "3.30.5",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-mention/-/extension-mention-3.30.5.tgz",
-            "integrity": "sha512-UFLZbue+GanPQgdDFbLWKnzd+ivWSSsfaFQGI2jj5jS6SNaMk0yAr5djiAmZEDMVfP3HmHpDwim9ZGzShYQPiQ==",
+            "version": "3.31.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-mention/-/extension-mention-3.31.3.tgz",
+            "integrity": "sha512-ygOPc3nQijSMUTbEdMeng12P1szk3znubA9xNi84f31VnR18VjmU0we8SIOSSVwDfm1GppSjRER2qHmX/wGIIw==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "3.30.5",
-                "@tiptap/pm": "3.30.5",
-                "@tiptap/suggestion": "3.30.5"
+                "@tiptap/core": "3.31.3",
+                "@tiptap/pm": "3.31.3",
+                "@tiptap/suggestion": "3.31.3"
             }
         },
         "node_modules/@tiptap/extension-node-range": {
-            "version": "3.30.5",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-node-range/-/extension-node-range-3.30.5.tgz",
-            "integrity": "sha512-c66LBRn6d/t2sY8WqS0nlNxPIgyrHGesnoHbR3RhkliSb7+pf3e2b5Osxxjlx3sAziKdwpwuXcmyCoR98Iv/xg==",
+            "version": "3.31.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-node-range/-/extension-node-range-3.31.3.tgz",
+            "integrity": "sha512-8/CKctvTNmzkPkqC9wxVY4TVhOax5WkqiImkvMb3Qv+OJgKC0pTlAhSS+ks3YYTbbmJuCYvHef3QuGiwRnu9gw==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "3.30.5",
-                "@tiptap/pm": "3.30.5"
+                "@tiptap/core": "3.31.3",
+                "@tiptap/pm": "3.31.3"
             }
         },
         "node_modules/@tiptap/extension-ordered-list": {
-            "version": "3.30.5",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-ordered-list/-/extension-ordered-list-3.30.5.tgz",
-            "integrity": "sha512-bUGUnSAgjZhoUWBtr+1wRJHF3NnNvuKQr6sQ8le1tJ2yvLq448ZsSZjZGvTNeLsy3GDKBoMJ0rqLUK34+nM3hg==",
+            "version": "3.31.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-ordered-list/-/extension-ordered-list-3.31.3.tgz",
+            "integrity": "sha512-mp3g11NgA/PYu8rj7J7Ez3l4qBy6WfTSmHIG4PZvEGG5w2oUAIkgb9DU7nPPzjmeme27oazFYZw+AtZA0+u4tw==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/extension-list": "3.30.5"
+                "@tiptap/extension-list": "3.31.3"
             }
         },
         "node_modules/@tiptap/extension-paragraph": {
-            "version": "3.30.5",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-paragraph/-/extension-paragraph-3.30.5.tgz",
-            "integrity": "sha512-GrNNlAImfQhYRtGE95YNAjcTclUUMPHs9JeE9vMgfcoKcOmZ6GsbWUdN0hA55xqwGaUjnroOVtf77K9z1EbkJQ==",
+            "version": "3.31.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-paragraph/-/extension-paragraph-3.31.3.tgz",
+            "integrity": "sha512-+iPku7wJfy5hbNDNLX8dveFtYVsZMmh7vztjuq8hT3mipSC4IByDehDbU8fzUCjfXiEzmI7mQn7c8LGmHULuzA==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "3.30.5"
+                "@tiptap/core": "3.31.3"
             }
         },
         "node_modules/@tiptap/extension-placeholder": {
-            "version": "3.30.5",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-placeholder/-/extension-placeholder-3.30.5.tgz",
-            "integrity": "sha512-WgkX4ImAAeV+Qe7ATJ+Gio2MmKWON1CKpCKPHWgCObaoMEaSmdoxXPmI9wXMuM+AJydJepp4n7U/V4TVts14rg==",
+            "version": "3.31.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-placeholder/-/extension-placeholder-3.31.3.tgz",
+            "integrity": "sha512-9jYtR8ELEw7GVaruyrm4oFkPcjig9Q+crc+dpmarhBNXUmxagCdlhVzNwCJ2WJRzvBAtx59sEYqNTU38Wx8S3A==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/extensions": "3.30.5"
+                "@tiptap/extensions": "3.31.3"
             }
         },
         "node_modules/@tiptap/extension-strike": {
-            "version": "3.30.5",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-strike/-/extension-strike-3.30.5.tgz",
-            "integrity": "sha512-r8IbWUm4YXNCkmc6h6dzuREQIGbO0x9z9l3GfQPUR3LxFtGssDLngE4dFXHRt/ejLWKEauy6clklf7LawtvYzw==",
+            "version": "3.31.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-strike/-/extension-strike-3.31.3.tgz",
+            "integrity": "sha512-G29bhKttYwcKHT+BI6emWVFol3RO/gUXxQVcmr/iT8LXXy7j8J6HFUnsKM+Kg5YlP1rxMRgsa65dbrQVahZi0A==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "3.30.5"
+                "@tiptap/core": "3.31.3"
             }
         },
         "node_modules/@tiptap/extension-text": {
-            "version": "3.30.5",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-3.30.5.tgz",
-            "integrity": "sha512-pOgj4mIGFlw4NUdA6PCTFP/MHrYWnOYiZRYeu0I3/Yo3iN4Am/CgYBLl8PWsNh+YPO2hA2DWs7ZMke9D2j5R+g==",
+            "version": "3.31.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-3.31.3.tgz",
+            "integrity": "sha512-gdsWtF+taeaCu6V+5Ct10fGo0ACUy1GnYtbb+mcathBt8OqbT+Ws60p/yEmKesBDz2Hn+B5IcWy6+2BBZl5ZTg==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "3.30.5"
+                "@tiptap/core": "3.31.3"
             }
         },
         "node_modules/@tiptap/extension-underline": {
-            "version": "3.30.5",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-underline/-/extension-underline-3.30.5.tgz",
-            "integrity": "sha512-u12G/WW2uFRY95BzrSAU9RW002K+7lFpSCL6fb7Puh8yLhek3lddOtAx0P+NI/PyMKtcoVMtBxoi+0mwVM7NPQ==",
+            "version": "3.31.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-underline/-/extension-underline-3.31.3.tgz",
+            "integrity": "sha512-HghdJaOwRqYzsAxqSyNyb+IWyOMcdCl8IoiBETA9BZCJAqdXzFLcuWp7CqCqJPam9dgkWosSoHqTCAO4nTBfpw==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "3.30.5"
+                "@tiptap/core": "3.31.3"
             }
         },
         "node_modules/@tiptap/extensions": {
-            "version": "3.30.5",
-            "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.30.5.tgz",
-            "integrity": "sha512-5x3OiCYBvXz0G5OGM8f7ka++1dh9EXdNRZ8IcMcEd+QwW4RPwvmJ2EjheA1eRRyMlcbNU7T+4IRlBXURlTetEA==",
+            "version": "3.31.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.31.3.tgz",
+            "integrity": "sha512-8sJNPGGUe8f3aDojcOW5cfVL7I5NrBbE0UWxG08qoi9Tea6qWbvQJsCR9tsrOapr/DaLr3kpbGZ9s1gEEfcNcA==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "3.30.5",
-                "@tiptap/pm": "3.30.5"
+                "@tiptap/core": "3.31.3",
+                "@tiptap/pm": "3.31.3"
             }
         },
         "node_modules/@tiptap/markdown": {
-            "version": "3.30.5",
-            "resolved": "https://registry.npmjs.org/@tiptap/markdown/-/markdown-3.30.5.tgz",
-            "integrity": "sha512-0yDt0AsiNHY0ZzlvELmzOmjfo55eJKV1euRYQp0aI5XPh+2YOdOm8cZqlhdHpJrN0wdrP/nVGxumsNmC/dqx4Q==",
+            "version": "3.31.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/markdown/-/markdown-3.31.3.tgz",
+            "integrity": "sha512-rBbYSxasseUoaBo15C8Yoaqafo7mJJzxwAwV9Z1OpLBvOroW9nQ0EbOdqaSYRw3/d9pP71B/3LNSzKyfyy+dpQ==",
             "license": "MIT",
             "dependencies": {
                 "marked": "^17.0.1"
@@ -6944,14 +7035,14 @@
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "3.30.5",
-                "@tiptap/pm": "3.30.5"
+                "@tiptap/core": "3.31.3",
+                "@tiptap/pm": "3.31.3"
             }
         },
         "node_modules/@tiptap/pm": {
-            "version": "3.30.5",
-            "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.30.5.tgz",
-            "integrity": "sha512-gufkLkW2tA6PZPjivYxDiGzTIIftwqhmYI6lvvKu2S4FbhcysJgMAe/GXVSywzCRVVex9SrvCe6RFYrqnwRitQ==",
+            "version": "3.31.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.31.3.tgz",
+            "integrity": "sha512-sZime0SWsz/k62W2WvHx5Ig7G2h7kVhrrmnqy+wEgIHfDwEfOlelRjaWCiBCFlF7dxGUntJusCh9FxlLhni0Ag==",
             "license": "MIT",
             "dependencies": {
                 "prosemirror-changeset": "^2.4.1",
@@ -6966,7 +7057,7 @@
                 "prosemirror-state": "^1.4.4",
                 "prosemirror-tables": "^1.8.5",
                 "prosemirror-transform": "^1.12.0",
-                "prosemirror-view": "^1.41.9"
+                "prosemirror-view": "^1.42.3"
             },
             "funding": {
                 "type": "github",
@@ -6974,35 +7065,35 @@
             }
         },
         "node_modules/@tiptap/starter-kit": {
-            "version": "3.30.5",
-            "resolved": "https://registry.npmjs.org/@tiptap/starter-kit/-/starter-kit-3.30.5.tgz",
-            "integrity": "sha512-cmDRvukpoqjQjhE96q+l3tCLNZZcJKehxK+00Sp9F4XbKecfM2QpZ2TRHh3vi8qhCeDQNyMoCqfNaqznIjLjIQ==",
+            "version": "3.31.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/starter-kit/-/starter-kit-3.31.3.tgz",
+            "integrity": "sha512-WKof9RewdmGHvWJ1wn0/HVNG2mV+HOgVRyJkKekuM9fgr6BZAAH/xZsWE1eon+94JnQ+KtK2ThydXQM/qc6b2A==",
             "license": "MIT",
             "dependencies": {
-                "@tiptap/core": "3.30.5",
-                "@tiptap/extension-blockquote": "3.30.5",
-                "@tiptap/extension-bold": "3.30.5",
-                "@tiptap/extension-bullet-list": "3.30.5",
-                "@tiptap/extension-code": "3.30.5",
-                "@tiptap/extension-code-block": "3.30.5",
-                "@tiptap/extension-document": "3.30.5",
-                "@tiptap/extension-dropcursor": "3.30.5",
-                "@tiptap/extension-gapcursor": "3.30.5",
-                "@tiptap/extension-hard-break": "3.30.5",
-                "@tiptap/extension-heading": "3.30.5",
-                "@tiptap/extension-horizontal-rule": "3.30.5",
-                "@tiptap/extension-italic": "3.30.5",
-                "@tiptap/extension-link": "3.30.5",
-                "@tiptap/extension-list": "3.30.5",
-                "@tiptap/extension-list-item": "3.30.5",
-                "@tiptap/extension-list-keymap": "3.30.5",
-                "@tiptap/extension-ordered-list": "3.30.5",
-                "@tiptap/extension-paragraph": "3.30.5",
-                "@tiptap/extension-strike": "3.30.5",
-                "@tiptap/extension-text": "3.30.5",
-                "@tiptap/extension-underline": "3.30.5",
-                "@tiptap/extensions": "3.30.5",
-                "@tiptap/pm": "3.30.5"
+                "@tiptap/core": "3.31.3",
+                "@tiptap/extension-blockquote": "3.31.3",
+                "@tiptap/extension-bold": "3.31.3",
+                "@tiptap/extension-bullet-list": "3.31.3",
+                "@tiptap/extension-code": "3.31.3",
+                "@tiptap/extension-code-block": "3.31.3",
+                "@tiptap/extension-document": "3.31.3",
+                "@tiptap/extension-dropcursor": "3.31.3",
+                "@tiptap/extension-gapcursor": "3.31.3",
+                "@tiptap/extension-hard-break": "3.31.3",
+                "@tiptap/extension-heading": "3.31.3",
+                "@tiptap/extension-horizontal-rule": "3.31.3",
+                "@tiptap/extension-italic": "3.31.3",
+                "@tiptap/extension-link": "3.31.3",
+                "@tiptap/extension-list": "3.31.3",
+                "@tiptap/extension-list-item": "3.31.3",
+                "@tiptap/extension-list-keymap": "3.31.3",
+                "@tiptap/extension-ordered-list": "3.31.3",
+                "@tiptap/extension-paragraph": "3.31.3",
+                "@tiptap/extension-strike": "3.31.3",
+                "@tiptap/extension-text": "3.31.3",
+                "@tiptap/extension-underline": "3.31.3",
+                "@tiptap/extensions": "3.31.3",
+                "@tiptap/pm": "3.31.3"
             },
             "funding": {
                 "type": "github",
@@ -7010,9 +7101,9 @@
             }
         },
         "node_modules/@tiptap/suggestion": {
-            "version": "3.30.5",
-            "resolved": "https://registry.npmjs.org/@tiptap/suggestion/-/suggestion-3.30.5.tgz",
-            "integrity": "sha512-kXlsY2GyXlVpYKp6uSedvvfACC4Phd0I8/Gp1/7ts8fYLlkVfGco6kgqOKHxT6HcUF1pGshxkDh9lfRCakkQEA==",
+            "version": "3.31.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/suggestion/-/suggestion-3.31.3.tgz",
+            "integrity": "sha512-z1OQ/Yx6seMZehi1AcmNkyJ8qkHQzybArmCyRdmreS4YL9C4bPMBe5lbMfFsArYs+KD5JyHwps5j7J/YE5BIuw==",
             "license": "MIT",
             "funding": {
                 "type": "github",
@@ -7020,27 +7111,27 @@
             },
             "peerDependencies": {
                 "@floating-ui/dom": "^1.0.0",
-                "@tiptap/core": "3.30.5",
-                "@tiptap/pm": "3.30.5"
+                "@tiptap/core": "3.31.3",
+                "@tiptap/pm": "3.31.3"
             }
         },
         "node_modules/@tiptap/vue-3": {
-            "version": "3.30.5",
-            "resolved": "https://registry.npmjs.org/@tiptap/vue-3/-/vue-3-3.30.5.tgz",
-            "integrity": "sha512-YRHacQy09nFcokAScICxJ6pWr5daWbsLJuBiMo+DJQlr1XLi6o/zFhh3eR9+DKluL4OY3IZDYBYZfDs7YZtJNg==",
+            "version": "3.31.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/vue-3/-/vue-3-3.31.3.tgz",
+            "integrity": "sha512-PNt0+rm7BXzhe/U+xlNnXBeJ6t9x2mE3902VXeIeEBxu5CrYLCJ0a5yHrof1jU3KwJrLOe/BtlGWjbq4qnTTfQ==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "optionalDependencies": {
-                "@tiptap/extension-bubble-menu": "^3.30.5",
-                "@tiptap/extension-floating-menu": "^3.30.5"
+                "@tiptap/extension-bubble-menu": "^3.31.3",
+                "@tiptap/extension-floating-menu": "^3.31.3"
             },
             "peerDependencies": {
                 "@floating-ui/dom": "^1.0.0",
-                "@tiptap/core": "3.30.5",
-                "@tiptap/pm": "3.30.5",
+                "@tiptap/core": "3.31.3",
+                "@tiptap/pm": "3.31.3",
                 "vue": "^3.0.0"
             }
         },
@@ -7106,12 +7197,6 @@
                 "@types/unist": "*"
             }
         },
-        "node_modules/@types/jsesc": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/@types/jsesc/-/jsesc-2.5.1.tgz",
-            "integrity": "sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw==",
-            "license": "MIT"
-        },
         "node_modules/@types/json-schema": {
             "version": "7.0.15",
             "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -7146,9 +7231,9 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "26.2.0",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
-            "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
+            "version": "26.4.1",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-26.4.1.tgz",
+            "integrity": "sha512-k97ENvZWtvA6yqz5/FS6a7duDgOPEeOQOc2iKS/nY6mX6qJUKtLnWzQS+Xj6tXweyj6ZcTAK2Qecetnvi9nCLA==",
             "license": "MIT",
             "dependencies": {
                 "undici-types": "~8.3.0"
@@ -7179,13 +7264,13 @@
             "license": "MIT"
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.67.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.67.0.tgz",
-            "integrity": "sha512-EgvsleTwS4E+WzzSvem8fAUubLwatMNF1B5hHSLQxcvs7q2dtRhGyujHwLJSYlG41niJ7GP24Aha2+0mb1b2kg==",
+            "version": "8.69.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.69.0.tgz",
+            "integrity": "sha512-ewfspqWvSxKSOaplqAUNbaSFO0eB6w1EtQ+esfYFRm3614Ty4uNtExkcbgd6nWsXphbqKyf9ZYdbZdv2xEoWEQ==",
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.67.0",
-                "@typescript-eslint/visitor-keys": "8.67.0"
+                "@typescript-eslint/types": "8.69.0",
+                "@typescript-eslint/visitor-keys": "8.69.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -7196,9 +7281,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.67.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.67.0.tgz",
-            "integrity": "sha512-sBtgslww8nsMYUjhdPBiSyUqSzT8uR6g93A2QXnQC8+cGdjz0CyaOdqHDRJb1AtORbZCNUJBBeFA/tNR2uQmww==",
+            "version": "8.69.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.69.0.tgz",
+            "integrity": "sha512-K3VrubUPhlo9VDBS6QdI8YB5j7ClpqLRdefcz6PFrhnwicehBweqQ9Evhl4l+FYz0HdDmMqIiSX0aldGRYtDCA==",
             "license": "MIT",
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -7209,12 +7294,12 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.67.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.67.0.tgz",
-            "integrity": "sha512-fkv8dHRDqfGtTHuJeebdrQ7cX6Ad4WAS00rgHh9UGvMycF1mjBfsxry1XsLIFhWZ6Judlh6UdzK+TYlbpCXgnA==",
+            "version": "8.69.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.69.0.tgz",
+            "integrity": "sha512-+rmdgPA+EXkNgKYvHvFfhrs35utXbwaC5PGpDquSXcoXQDKUA5UjV0LmTucG/4JXkM31BTu4TilHtrN8IVBe8w==",
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.67.0",
+                "@typescript-eslint/types": "8.69.0",
                 "eslint-visitor-keys": "^5.0.0"
             },
             "engines": {
@@ -7558,9 +7643,9 @@
             }
         },
         "node_modules/@ungap/structured-clone": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
-            "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.4.0.tgz",
+            "integrity": "sha512-1mEZtMKPM09vDmQt5y7YvmN2+DFTP7Tg0EWXdic8/C6VRnpb33e4ghisCIE3WZjsE2N8mf+QV1Zqh7ZFYLWInQ==",
             "license": "ISC"
         },
         "node_modules/@unhead/bundler": {
@@ -7640,30 +7725,6 @@
                 "webpack": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/@unocss/config": {
-            "version": "66.8.0",
-            "resolved": "https://registry.npmjs.org/@unocss/config/-/config-66.8.0.tgz",
-            "integrity": "sha512-iW6A4h4PaXADWMskdWvjqodQWPegyRhzzP7JAVt+e8uIgcvreQiq0NseQ1WATHW6/x4DvkpYBud/y4jlXJE2Iw==",
-            "license": "MIT",
-            "dependencies": {
-                "@unocss/core": "66.8.0",
-                "colorette": "^2.0.20",
-                "consola": "^3.4.2",
-                "unconfig": "^7.5.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/antfu"
-            }
-        },
-        "node_modules/@unocss/core": {
-            "version": "66.8.0",
-            "resolved": "https://registry.npmjs.org/@unocss/core/-/core-66.8.0.tgz",
-            "integrity": "sha512-XQjALtWyK2aDKlBbIAufCwSu8QD6iv6qEGygeYcP1DLsQzRwBy8zQq3A+DqVUyFNJGMhXHSNeWeiLKjFnTzBOg==",
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/antfu"
             }
         },
         "node_modules/@vercel/nft": {
@@ -7841,39 +7902,39 @@
             }
         },
         "node_modules/@vue/compiler-core": {
-            "version": "3.5.41",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.41.tgz",
-            "integrity": "sha512-q0Xtv/F9w2YO/7htQhtiL+Ev2WCJbe5N2hc+XfgyKkEKqWpSxknmT8QOuGdEKNdjPq0c3F7rNpFkTo3Kfrm7pg==",
+            "version": "3.5.42",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.42.tgz",
+            "integrity": "sha512-2Ye1ilMtKXxl8qZUrQ5j0CdgenFp/HFQmta6rfRyfEsTG69L6Wk+tWuNoHYHMx9E8tF2Slvdg1FuwDvAXdy1LQ==",
             "license": "MIT",
             "dependencies": {
                 "@babel/parser": "^7.29.8",
-                "@vue/shared": "3.5.41",
+                "@vue/shared": "3.5.42",
                 "entities": "^7.0.1",
                 "estree-walker": "^2.0.2",
                 "source-map-js": "^1.2.1"
             }
         },
         "node_modules/@vue/compiler-dom": {
-            "version": "3.5.41",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.41.tgz",
-            "integrity": "sha512-oKacVfNglLvGjnS6BXOlGL7EyG2h8X03pqXCjzotRZUaXGjbrTJUnVAQjrCqUnS+lyu31nwQjZY/d817GmCnfw==",
+            "version": "3.5.42",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.42.tgz",
+            "integrity": "sha512-qbhQZEFmycr+ni/qyuccS4sucNN7VAbDfbkvNxWOX2VfgFm90MNs3/UhRNKoPMEIVn0F8gdlYjLPvqxHwHeQOA==",
             "license": "MIT",
             "dependencies": {
-                "@vue/compiler-core": "3.5.41",
-                "@vue/shared": "3.5.41"
+                "@vue/compiler-core": "3.5.42",
+                "@vue/shared": "3.5.42"
             }
         },
         "node_modules/@vue/compiler-sfc": {
-            "version": "3.5.41",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.41.tgz",
-            "integrity": "sha512-XJhip7R2wy6vX3knCxdZN4KracFaZUef58s1KYewqluedHIJaPIVfXoYT7MF1F8nCvv6k8bWWxDC8opMkg1VTQ==",
+            "version": "3.5.42",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.42.tgz",
+            "integrity": "sha512-fkCAFB4okcAANGMThboWnScp/gzWjU0ZSkVnjTIiplmMDq2uq0tIB3j+xVu4rhv5rvOgBySCysudmbMd6xRRqw==",
             "license": "MIT",
             "dependencies": {
                 "@babel/parser": "^7.29.8",
-                "@vue/compiler-core": "3.5.41",
-                "@vue/compiler-dom": "3.5.41",
-                "@vue/compiler-ssr": "3.5.41",
-                "@vue/shared": "3.5.41",
+                "@vue/compiler-core": "3.5.42",
+                "@vue/compiler-dom": "3.5.42",
+                "@vue/compiler-ssr": "3.5.42",
+                "@vue/shared": "3.5.42",
                 "estree-walker": "^2.0.2",
                 "magic-string": "^0.30.21",
                 "postcss": "^8.5.19",
@@ -7890,13 +7951,13 @@
             }
         },
         "node_modules/@vue/compiler-ssr": {
-            "version": "3.5.41",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.41.tgz",
-            "integrity": "sha512-U3v5OejKEGqOI0Wy0+Sz7hGuIFZHA4LSXzrNM3IMIeDyJEBBfTpX26n3SDgToRpP2bLc9FfI2j/kSgcJ8Emq5A==",
+            "version": "3.5.42",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.42.tgz",
+            "integrity": "sha512-xmLk3wLkbizPAiLyomjgFFosf2ys9b5Ghb+oh/k2tnvipNz8OFrQOiTcWCzyK7MpBp9KkyGtfvgfLUivbmuGYA==",
             "license": "MIT",
             "dependencies": {
-                "@vue/compiler-dom": "3.5.41",
-                "@vue/shared": "3.5.41"
+                "@vue/compiler-dom": "3.5.42",
+                "@vue/shared": "3.5.42"
             }
         },
         "node_modules/@vue/devtools-api": {
@@ -7952,9 +8013,9 @@
             "license": "MIT"
         },
         "node_modules/@vue/language-core": {
-            "version": "3.3.9",
-            "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.3.9.tgz",
-            "integrity": "sha512-in/68oAa4BCtVY6n/nkuhLIkV8DHYd2UivedJ6cMZ6UYtlq9jaoaSNUBHYCVO44z3nKg7MdE5OBoHKt5SxeBKQ==",
+            "version": "3.3.11",
+            "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.3.11.tgz",
+            "integrity": "sha512-QJmpliwAVpC/OxubIByPAhNzsQPRc8/gxlN2qnVzVfIMjMDz/9RnXRFoetjz5yEgXVXyp4LqhXq3V53PjmNzFw==",
             "license": "MIT",
             "dependencies": {
                 "@volar/language-core": "2.4.28",
@@ -7967,51 +8028,51 @@
             }
         },
         "node_modules/@vue/reactivity": {
-            "version": "3.5.41",
-            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.41.tgz",
-            "integrity": "sha512-rznsqKM0np0x18EjzF8x88MpEhdNsffbvFbckLL5+oUKz1BxAImEmO7J1ArRYSyo6aQaVoBDp7jEkT91OOxydA==",
+            "version": "3.5.42",
+            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.42.tgz",
+            "integrity": "sha512-TzNNfKpb7hDxbQltwAut8VDQA5YP+BuRlxntHUuRjyKwlMvmAPbs3unhCvieijifY6vFfVBwsS7wG/C7uq+bEQ==",
             "license": "MIT",
             "dependencies": {
-                "@vue/shared": "3.5.41"
+                "@vue/shared": "3.5.42"
             }
         },
         "node_modules/@vue/runtime-core": {
-            "version": "3.5.41",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.41.tgz",
-            "integrity": "sha512-Vcry58hiAKwGen9Z1jUZE0feFsNArPCMOImYI8el48A9Idf6DuQYD0U05zZIF2Iad1hGhPSvcbBbAOhNr55fhg==",
+            "version": "3.5.42",
+            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.42.tgz",
+            "integrity": "sha512-9uACtuHs7vJGkm5Bp3xu4xRDLFTIYy5DgxpToVjqGIAhAEKwQfsaLvKINhM6nFVp6bZPRFGdDqd1g52MqKsotA==",
             "license": "MIT",
             "dependencies": {
-                "@vue/reactivity": "3.5.41",
-                "@vue/shared": "3.5.41"
+                "@vue/reactivity": "3.5.42",
+                "@vue/shared": "3.5.42"
             }
         },
         "node_modules/@vue/runtime-dom": {
-            "version": "3.5.41",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.41.tgz",
-            "integrity": "sha512-3vVBahVBS9+U6cmXBLyb8nE6/yYo4J/CGI9eVFs3KiMc0YHuudwKyShTD65jtJy/L9PUUxNAFu4cj4LiJ0UFbw==",
+            "version": "3.5.42",
+            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.42.tgz",
+            "integrity": "sha512-rsCmhiWLaRxGltLwhlCWyYkFn7WAbKRh0q17eZ1A6Dq6eqc2ACQ61IIryxz0LrsvCzHSilLA9JHovVwM8CNE2g==",
             "license": "MIT",
             "dependencies": {
-                "@vue/reactivity": "3.5.41",
-                "@vue/runtime-core": "3.5.41",
-                "@vue/shared": "3.5.41",
+                "@vue/reactivity": "3.5.42",
+                "@vue/runtime-core": "3.5.42",
+                "@vue/shared": "3.5.42",
                 "csstype": "^3.2.3"
             }
         },
         "node_modules/@vue/server-renderer": {
-            "version": "3.5.41",
-            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.41.tgz",
-            "integrity": "sha512-n6hx/pNFfbD6SuyeuMVkvqox8bwf/ET9JlA/kAz/imw8sw++wkqKe2mHX5KutjPpbKE4Z56yTHszoOjGMI9igQ==",
+            "version": "3.5.42",
+            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.42.tgz",
+            "integrity": "sha512-2++5dUyYS4gvo7xQXSECUDhB7TS0aOl5SeVfC5qSq1Jgfhjvegw1zqhwTIR3imZ+QYPJQw9gfcFvXGAjGZ7ajQ==",
             "license": "MIT",
             "dependencies": {
-                "@vue/compiler-ssr": "3.5.41",
-                "@vue/runtime-dom": "3.5.41",
-                "@vue/shared": "3.5.41"
+                "@vue/compiler-ssr": "3.5.42",
+                "@vue/runtime-dom": "3.5.42",
+                "@vue/shared": "3.5.42"
             }
         },
         "node_modules/@vue/shared": {
-            "version": "3.5.41",
-            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.41.tgz",
-            "integrity": "sha512-IOnwSCma8j+9xJT6b8H0dEYidC80NsYmNMlZxRsukYcSoGaDBohog5hDxzeUXdFeGWFA++vWvxqOmrr96VlqMA==",
+            "version": "3.5.42",
+            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.42.tgz",
+            "integrity": "sha512-2rPxex1jQf4jvl9MOHl6YaXCPcrNqz/FstMOEh3QWY+/OME9nQTvl9WYeCwhW7AFjaR0SnngZGlp/wkR6rkI6g==",
             "license": "MIT"
         },
         "node_modules/@vueuse/core": {
@@ -8124,6 +8185,12 @@
             "integrity": "sha512-6aN99yL695Hi9SuIk1oC88l9o0gmxL1nGWWQ/kNy81HigJ0FoaoTXpytCj6ItzgyCEwA9kF1wixsTuv5cjsgng==",
             "license": "MIT"
         },
+        "node_modules/@workflow/serde": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@workflow/serde/-/serde-4.1.0.tgz",
+            "integrity": "sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==",
+            "license": "Apache-2.0"
+        },
         "node_modules/abbrev": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-3.0.1.tgz",
@@ -8198,18 +8265,17 @@
             }
         },
         "node_modules/ai": {
-            "version": "6.0.258",
-            "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.258.tgz",
-            "integrity": "sha512-b1GzG2Lk2rGaVcC+IMowfUQdFCyn7IPxfpQo/a0J7PJ2VLTfoq98P9Dx0B+QNl7vpT900iYFBmYfMw5qMxnuUg==",
+            "version": "7.0.93",
+            "resolved": "https://registry.npmjs.org/ai/-/ai-7.0.93.tgz",
+            "integrity": "sha512-CJss6zb9mlltk/mCr8qom20NBnqEQxVawkqwtT62tCwsxilZpXfHNRMRwcS3XRpzdP1kEluVuDBUayYWEEd95g==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@ai-sdk/gateway": "3.0.176",
-                "@ai-sdk/provider": "3.0.15",
-                "@ai-sdk/provider-utils": "4.0.46",
-                "@opentelemetry/api": "^1.9.0"
+                "@ai-sdk/gateway": "4.0.75",
+                "@ai-sdk/provider": "4.0.10",
+                "@ai-sdk/provider-utils": "5.0.36"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=22"
             },
             "peerDependencies": {
                 "zod": "^3.25.76 || ^4.1.8"
@@ -8503,9 +8569,9 @@
             "license": "MIT"
         },
         "node_modules/autoprefixer": {
-            "version": "10.5.4",
-            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.4.tgz",
-            "integrity": "sha512-MaU0U/za7N3r6brxD4YB/l4NSrFzLPlANv6wEuQVaIPlD3L4W9rFcQPbL/EilY9BHhHvhfcz3gInDLrEtWT4EA==",
+            "version": "10.5.5",
+            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.5.tgz",
+            "integrity": "sha512-uiRYvQYe/nNSzBJ7OUnd2/TZVsAdob3blml44teEpee9Cc1f4rGZFewO+JT3Wo8mgFOSzNqes4FHZn/Qz8WOuw==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -8522,8 +8588,8 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "browserslist": "^4.28.6",
-                "caniuse-lite": "^1.0.30001806",
+                "browserslist": "^4.28.9",
+                "caniuse-lite": "^1.0.30001810",
                 "fraction.js": "^5.3.4",
                 "picocolors": "^1.1.1",
                 "postcss-value-parser": "^4.2.0"
@@ -8587,9 +8653,9 @@
             }
         },
         "node_modules/bare-events": {
-            "version": "2.9.1",
-            "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
-            "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
+            "version": "2.9.2",
+            "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.2.tgz",
+            "integrity": "sha512-AIPKioV7/Y/8KfZ3AAhjPJxLLbY49S64Ym5DakZlUg75qQiTgUq9hEJoEwa4eUezPUlXRy/i5NpsKvo9jgKmoA==",
             "license": "Apache-2.0",
             "peerDependencies": {
                 "bare-abort-controller": "*"
@@ -8601,9 +8667,9 @@
             }
         },
         "node_modules/bare-fs": {
-            "version": "4.8.0",
-            "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.8.0.tgz",
-            "integrity": "sha512-fM+MhCvdQhZ7NV6S95a07gPSqjIYKn6mFaXfx266wN3ajZGl/+1AzH+ubkXQ0fFZvOe2nk9VHkzdYkQE5zMV3Q==",
+            "version": "4.8.1",
+            "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.8.1.tgz",
+            "integrity": "sha512-N1nnXdHZAOSstz0XiHikGS4HGMH4CnSwhqWdGQQMqqdvp4Jybm9sE3R1WVnpWVd4SFkc8ryPDBLViNLwiEqECg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "bare-events": "^2.5.4",
@@ -8625,15 +8691,15 @@
             }
         },
         "node_modules/bare-path": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.1.1.tgz",
-            "integrity": "sha512-JprUlveX3QjApC1cTpsUOiscADftCGVWkzitbHsRqv84hzYwYHw2mbluddsq5TvI8mH/8Ov1f4BiMAdcB0oYnQ==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.1.2.tgz",
+            "integrity": "sha512-ZyKbsuuqK6Ag0K8pX6V5Txq6XeJRvY+wXucnFGRjiyVYP9YWDpIQugk/b+enRYrEYBJaqLzghRQpXPMR7341Nw==",
             "license": "Apache-2.0"
         },
         "node_modules/bare-stream": {
-            "version": "2.13.3",
-            "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.3.tgz",
-            "integrity": "sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==",
+            "version": "2.13.4",
+            "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.4.tgz",
+            "integrity": "sha512-PcrQ8lVLbiJscNm1Kez+Yp4Gy4AHGcN1lzwjvf5NybWen7VvEgUfyfnXYJ2zNqWnzOfCb1Abq6lH8ti0syQszA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "b4a": "^1.8.1",
@@ -8658,9 +8724,9 @@
             }
         },
         "node_modules/bare-url": {
-            "version": "2.5.2",
-            "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.5.2.tgz",
-            "integrity": "sha512-L13PCJzKG8RGvx8V1/DdMi12ERhC3tprr7/8a94BxpmnRsFqxh5XZNdhtMxu5HPkRshYOOWRGY8lDP7ZhpG9Cg==",
+            "version": "2.5.4",
+            "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.5.4.tgz",
+            "integrity": "sha512-Gxa7UVWBr0/edU1b+TJhn/AZvMQUj9OGspvYsaTYQrAbZA4BOTZGL3LiZxvD+CeMlDH4juwD84+eTAp/bLYW5g==",
             "license": "Apache-2.0",
             "dependencies": {
                 "bare-path": "^3.0.0"
@@ -8687,9 +8753,9 @@
             "license": "MIT"
         },
         "node_modules/baseline-browser-mapping": {
-            "version": "2.11.15",
-            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.15.tgz",
-            "integrity": "sha512-FwMjJJ7HnyZpWe+oWxegG0fezZyBZUagI5LZEoO3GCbtbKNwRfMH9Ue5d5v01PNePBy1QSfPSDTTeVL0Hb9EzA==",
+            "version": "2.11.21",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.21.tgz",
+            "integrity": "sha512-uh8vpY/1/YyFkunIDFH/12p7/7VdPKA1hejMVEbdkEaWnUz0Hesvx5EbiU6XxjyHZIOju+ZMbQJkRh+es3/spQ==",
             "license": "Apache-2.0",
             "bin": {
                 "baseline-browser-mapping": "dist/cli.cjs"
@@ -8847,9 +8913,9 @@
             }
         },
         "node_modules/browserslist": {
-            "version": "4.28.8",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
-            "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
+            "version": "4.28.9",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.9.tgz",
+            "integrity": "sha512-EWazOblFYUvlGZcfGhPUPmYh3nikUxBVb+y9MJun5f3hBi812X+8MSQTujLBtgK3cf51fJWbWfOjyeO954d+Eg==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -8866,11 +8932,11 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "baseline-browser-mapping": "^2.11.12",
-                "caniuse-lite": "^1.0.30001809",
-                "electron-to-chromium": "^1.5.402",
-                "node-releases": "^2.0.53",
-                "update-browserslist-db": "^1.3.0"
+                "baseline-browser-mapping": "^2.11.20",
+                "caniuse-lite": "^1.0.30001810",
+                "electron-to-chromium": "^1.5.420",
+                "node-releases": "^2.0.54",
+                "update-browserslist-db": "^1.3.2"
             },
             "bin": {
                 "browserslist": "cli.js"
@@ -8970,6 +9036,20 @@
                 }
             }
         },
+        "node_modules/cacheable": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.5.0.tgz",
+            "integrity": "sha512-60cyAOytib/OzBw1JNSoSV/boK1AtHryDIjvVBk7XbN4ugfkM3+Sry7fEjNgPMGgOjuaZPAp8ruZ0Cxafwyq9g==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@cacheable/memory": "^2.2.0",
+                "@cacheable/utils": "^2.5.0",
+                "hookified": "^1.15.0",
+                "keyv": "^5.6.0",
+                "qified": "^0.10.1"
+            }
+        },
         "node_modules/call-bind": {
             "version": "1.0.9",
             "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
@@ -9028,9 +9108,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001809",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001809.tgz",
-            "integrity": "sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==",
+            "version": "1.0.30001810",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+            "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -9224,12 +9304,6 @@
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
             "license": "MIT"
         },
-        "node_modules/colorette": {
-            "version": "2.0.20",
-            "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
-            "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
-            "license": "MIT"
-        },
         "node_modules/colortranslator": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/colortranslator/-/colortranslator-5.0.0.tgz",
@@ -9237,26 +9311,30 @@
             "license": "Apache-2.0"
         },
         "node_modules/comark": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/comark/-/comark-0.4.0.tgz",
-            "integrity": "sha512-s+wZc9FDgxJDxS3oLhDhthuc8EFggd7oEQaGKEFSw/UbECEwM3qMgW/T3dk6eoNTuy+PNSAyPQtjyKZJfudlbA==",
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/comark/-/comark-0.6.2.tgz",
+            "integrity": "sha512-hlWa7KlGPfRxovQavnHZlLlTUKrfwE7/o4ewCY0FzqFtRvVT8VdslrumQwELIiK9utsurpoSWCBFj1yVMtDOtw==",
             "license": "MIT",
             "dependencies": {
                 "entities": "^8.0.0",
                 "htmlparser2": "^12.0.0",
-                "js-yaml": "^4.1.1",
-                "markdown-exit": "1.0.0-beta.9"
+                "js-yaml": "^5.2.1",
+                "markdown-exit": "1.1.0-beta.2"
             },
             "peerDependencies": {
                 "beautiful-mermaid": "^1.1.3",
-                "katex": "^0.16.45",
-                "shiki": "^4.0.0"
+                "katex": "^0.17.0",
+                "rangi": "^2.2.0",
+                "shiki": "^4.3.1"
             },
             "peerDependenciesMeta": {
                 "beautiful-mermaid": {
                     "optional": true
                 },
                 "katex": {
+                    "optional": true
+                },
+                "rangi": {
                     "optional": true
                 },
                 "shiki": {
@@ -9274,6 +9352,28 @@
             },
             "funding": {
                 "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
+        "node_modules/comark/node_modules/js-yaml": {
+            "version": "5.4.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.4.1.tgz",
+            "integrity": "sha512-28R/k+NAjeuf7+CKlTxWZVExJGwVVLwY06DgEnOMz2gEpfNkDcD7QvyiVPT0xy0XXhU8vHsd4Ot42OOPdJG7dQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nodeca"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "argparse": "^2.0.1"
+            },
+            "bin": {
+                "js-yaml": "bin/js-yaml.mjs"
             }
         },
         "node_modules/comma-separated-tokens": {
@@ -9484,16 +9584,16 @@
             }
         },
         "node_modules/css-select": {
-            "version": "5.2.2",
-            "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
-            "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/css-select/-/css-select-6.0.0.tgz",
+            "integrity": "sha512-rZZVSLle8v0+EY8QAkDWrKhpgt6SA5OtHsgBnsj6ZaLb5dmDVOWUDtQitd9ydxxvEjhewNudS6eTVU7uOyzvXw==",
             "license": "BSD-2-Clause",
             "dependencies": {
                 "boolbase": "^1.0.0",
-                "css-what": "^6.1.0",
-                "domhandler": "^5.0.2",
-                "domutils": "^3.0.1",
-                "nth-check": "^2.0.1"
+                "css-what": "^7.0.0",
+                "domhandler": "^5.0.3",
+                "domutils": "^3.2.2",
+                "nth-check": "^2.1.1"
             },
             "funding": {
                 "url": "https://github.com/sponsors/fb55"
@@ -9580,9 +9680,9 @@
             }
         },
         "node_modules/css-what": {
-            "version": "6.2.2",
-            "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
-            "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/css-what/-/css-what-7.0.0.tgz",
+            "integrity": "sha512-wD5oz5xibMOPHzy13CyGmogB3phdvcDaB5t0W/Nr5Z2O/agcB8YwOz6e2Lsp10pNDzBoDO9nVa3RGs/2BttpHQ==",
             "license": "BSD-2-Clause",
             "engines": {
                 "node": ">= 6"
@@ -9604,12 +9704,12 @@
             }
         },
         "node_modules/cssnano": {
-            "version": "8.0.6",
-            "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-8.0.6.tgz",
-            "integrity": "sha512-KDwqW0R35qIGDDWse4vRhrNtF558sUOcfuqCbB/h0bUP4+aBUpbGT5X2bQlE1gEACk+nDFAL045VyesanJFEug==",
+            "version": "8.0.10",
+            "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-8.0.10.tgz",
+            "integrity": "sha512-aMlBsvQW5g1b8vfPnkuy5Bk7g/jyRsf5eMpbhe4nKnePx+n2IrC0L6dFqnd3r4/OGNIYGEHfAt09oywi84fWKQ==",
             "license": "MIT",
             "dependencies": {
-                "cssnano-preset-default": "^8.0.6",
+                "cssnano-preset-default": "^8.0.10",
                 "lilconfig": "^3.1.3"
             },
             "engines": {
@@ -9624,27 +9724,27 @@
             }
         },
         "node_modules/cssnano-preset-default": {
-            "version": "8.0.6",
-            "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-8.0.6.tgz",
-            "integrity": "sha512-U5MLdiyveJNVCVR0uISgHvCkoYLLB0xeJZSY+VnBESzv1lhY04x54u9MYUNvIKmEs6hwqHVdzztajBOUf8VD4A==",
+            "version": "8.0.10",
+            "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-8.0.10.tgz",
+            "integrity": "sha512-34uq3q7OXgmfxXn+MHTgIqysCLH7zRZZUMAwrBiO09F5/KLVD33iDFNRRUNYStKdj0SaAIUVr6Akao2Fpp0aVA==",
             "license": "MIT",
             "dependencies": {
                 "browserslist": "^4.28.8",
                 "cssnano-utils": "^6.0.4",
                 "postcss-calc": "^10.1.1",
-                "postcss-colormin": "^8.0.4",
+                "postcss-colormin": "^8.0.5",
                 "postcss-convert-values": "^8.0.4",
                 "postcss-discard-comments": "^8.0.4",
                 "postcss-discard-duplicates": "^8.0.4",
-                "postcss-discard-empty": "^8.0.4",
+                "postcss-discard-empty": "^8.0.5",
                 "postcss-discard-overridden": "^8.0.4",
                 "postcss-merge-longhand": "^8.0.4",
-                "postcss-merge-rules": "^8.0.4",
+                "postcss-merge-rules": "^8.0.5",
                 "postcss-minify-font-values": "^8.0.4",
-                "postcss-minify-gradients": "^8.0.4",
+                "postcss-minify-gradients": "^8.0.6",
                 "postcss-minify-params": "^8.0.4",
                 "postcss-minify-selectors": "^8.0.5",
-                "postcss-normalize-charset": "^8.0.4",
+                "postcss-normalize-charset": "^8.0.5",
                 "postcss-normalize-display-values": "^8.0.4",
                 "postcss-normalize-positions": "^8.0.4",
                 "postcss-normalize-repeat-style": "^8.0.4",
@@ -9652,11 +9752,11 @@
                 "postcss-normalize-timing-functions": "^8.0.4",
                 "postcss-normalize-unicode": "^8.0.4",
                 "postcss-normalize-url": "^8.0.4",
-                "postcss-normalize-whitespace": "^8.0.4",
-                "postcss-ordered-values": "^8.0.4",
-                "postcss-reduce-initial": "^8.0.4",
+                "postcss-normalize-whitespace": "^8.0.5",
+                "postcss-ordered-values": "^8.0.5",
+                "postcss-reduce-initial": "^8.0.5",
                 "postcss-reduce-transforms": "^8.0.4",
-                "postcss-svgo": "^8.0.5",
+                "postcss-svgo": "^8.0.6",
                 "postcss-unique-selectors": "^8.0.4"
             },
             "engines": {
@@ -9717,48 +9817,11 @@
             "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
             "license": "MIT"
         },
-        "node_modules/culori": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/culori/-/culori-4.0.2.tgz",
-            "integrity": "sha512-1+BhOB8ahCn4O0cep0Sh2l9KCOfOdY+BXJnKMHFFzDEouSr/el18QwXEMRlOj9UY5nCeA8UN3a/82rUWRBeyBw==",
-            "license": "MIT",
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            }
-        },
         "node_modules/db0": {
-            "version": "0.3.4",
-            "resolved": "https://registry.npmjs.org/db0/-/db0-0.3.4.tgz",
-            "integrity": "sha512-RiXXi4WaNzPTHEOu8UPQKMooIbqOEyqA1t7Z6MsdxSCeb8iUC9ko3LcmsLmeUt2SM5bctfArZKkRQggKZz7JNw==",
-            "license": "MIT",
-            "peerDependencies": {
-                "@electric-sql/pglite": "*",
-                "@libsql/client": "*",
-                "better-sqlite3": "*",
-                "drizzle-orm": "*",
-                "mysql2": "*",
-                "sqlite3": "*"
-            },
-            "peerDependenciesMeta": {
-                "@electric-sql/pglite": {
-                    "optional": true
-                },
-                "@libsql/client": {
-                    "optional": true
-                },
-                "better-sqlite3": {
-                    "optional": true
-                },
-                "drizzle-orm": {
-                    "optional": true
-                },
-                "mysql2": {
-                    "optional": true
-                },
-                "sqlite3": {
-                    "optional": true
-                }
-            }
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/db0/-/db0-0.4.1.tgz",
+            "integrity": "sha512-6RBY/bSn42UrqATwsiULj2uYFyEykB3XeA/NLIVQeHNXlYV6D4Idxx3/aa6k5Y45Dwzx7sygeLotnqHWSeURYA==",
+            "license": "MIT"
         },
         "node_modules/debug": {
             "version": "4.4.3",
@@ -9946,9 +10009,9 @@
             }
         },
         "node_modules/devalue": {
-            "version": "5.9.0",
-            "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.9.0.tgz",
-            "integrity": "sha512-RWrqdArjvPbsATEhOPUo6Wndc/iWnkWKlhIrdlF3zMMYo/c3CVtoaVAyLtWxz5h8nSlkHzxnzV2uLydPXmtF+A==",
+            "version": "5.9.2",
+            "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.9.2.tgz",
+            "integrity": "sha512-po4PAY5c53tw5XMocSnf8A/5OHhbbUftpr93aEN6BBoAdntUmK7vu7wOATqvt7cXO7m1Cl4gMVn6p7n6n4mj0w==",
             "license": "MIT"
         },
         "node_modules/devlop": {
@@ -9980,44 +10043,44 @@
             "license": "MIT"
         },
         "node_modules/docus": {
-            "version": "5.12.3",
-            "resolved": "https://registry.npmjs.org/docus/-/docus-5.12.3.tgz",
-            "integrity": "sha512-v5CF/Ta3+aAzuUKwPsFwSSCACXh9QRWbBZENwUyheajATnPrSnql+oHbDzANM+GBwDvmPpCBhzHsjKrdZZR0cw==",
+            "version": "5.13.0",
+            "resolved": "https://registry.npmjs.org/docus/-/docus-5.13.0.tgz",
+            "integrity": "sha512-RWAFlYfdDedJrjmFSmrr7Vcq939i2kmQklusDgIatWIm2gSPZUvXpqlNiyR7V5UYKhZl4fMzjlTtfV5rJiMPnQ==",
             "license": "MIT",
             "dependencies": {
-                "@ai-sdk/gateway": "^3.0.133",
-                "@ai-sdk/mcp": "^1.0.52",
-                "@ai-sdk/vue": "^3.0.208",
-                "@comark/vue": "^0.4.0",
-                "@iconify-json/lucide": "^1.2.114",
-                "@iconify-json/simple-icons": "^1.2.87",
-                "@iconify-json/vscode-icons": "^1.2.59",
-                "@nuxt/content": "^3.14.0",
-                "@nuxt/image": "^2.0.0",
-                "@nuxt/kit": "^4.4.8",
-                "@nuxt/ui": "^4.9.0",
-                "@nuxtjs/i18n": "^10.4.0",
-                "@nuxtjs/mcp-toolkit": "^0.17.2",
-                "@nuxtjs/mdc": "^0.22.0",
-                "@nuxtjs/robots": "^6.1.1",
-                "@shikijs/core": "^4.2.0",
-                "@shikijs/engine-javascript": "^4.2.0",
-                "@shikijs/langs": "^4.2.0",
-                "@shikijs/stream": "^4.2.0",
-                "@shikijs/themes": "^4.2.0",
-                "@takumi-rs/core": "^1.8.7",
-                "@vueuse/core": "^14.3.0",
-                "ai": "^6.0.208",
+                "@ai-sdk/gateway": "^4.0.62",
+                "@ai-sdk/mcp": "^2.0.36",
+                "@ai-sdk/vue": "^4.0.77",
+                "@comark/vue": "^0.6.2",
+                "@iconify-json/lucide": "^1.2.125",
+                "@iconify-json/simple-icons": "^1.2.93",
+                "@iconify-json/vscode-icons": "^1.2.74",
+                "@nuxt/content": "^3.15.2",
+                "@nuxt/image": "^2.1.0",
+                "@nuxt/kit": "^4.5.2",
+                "@nuxt/ui": "^4.11.0",
+                "@nuxtjs/i18n": "^10.6.0",
+                "@nuxtjs/mcp-toolkit": "^0.19.0",
+                "@nuxtjs/mdc": "^0.22.2",
+                "@nuxtjs/robots": "^6.2.0",
+                "@shikijs/core": "^4.4.3",
+                "@shikijs/engine-javascript": "^4.4.3",
+                "@shikijs/langs": "^4.4.3",
+                "@shikijs/stream": "^4.4.3",
+                "@shikijs/themes": "^4.4.3",
+                "@takumi-rs/core": "^2.10.0",
+                "@vueuse/core": "^14.4.0",
+                "ai": "^7.0.77",
                 "defu": "^6.1.7",
-                "exsolve": "^1.1.0",
+                "exsolve": "^1.1.1",
                 "git-url-parse": "^16.1.0",
-                "motion-v": "^2.3.0",
+                "motion-v": "^2.4.0",
                 "nuxt-llms": "^0.2.0",
-                "nuxt-og-image": "~6.6.0",
+                "nuxt-og-image": "~6.7.8",
                 "pathe": "^2.0.3",
                 "pkg-types": "^2.3.1",
                 "scule": "^1.3.0",
-                "tailwindcss": "^4.3.1",
+                "tailwindcss": "^4.3.3",
                 "ufo": "^1.6.4",
                 "yaml": "^2.9.0",
                 "zod": "^4.4.3",
@@ -10026,153 +10089,6 @@
             "peerDependencies": {
                 "better-sqlite3": "12.x",
                 "nuxt": "4.x"
-            }
-        },
-        "node_modules/docus/node_modules/@nuxt/content": {
-            "version": "3.15.2",
-            "resolved": "https://registry.npmjs.org/@nuxt/content/-/content-3.15.2.tgz",
-            "integrity": "sha512-jBK48RbA5RIt2SdtHPBcu4eX8+PYVsspbN+Cfx52kbpl8uXCiwjFudqGZrl2yqRQuEqVDYk9FGIOvWiMarLDtA==",
-            "license": "MIT",
-            "dependencies": {
-                "@nuxt/kit": "^4.5.0",
-                "@nuxtjs/mdc": "^0.22.2",
-                "@shikijs/langs": "^4.3.1",
-                "@sqlite.org/sqlite-wasm": "3.53.0-build1",
-                "@standard-schema/spec": "^1.1.0",
-                "@webcontainer/env": "^1.1.1",
-                "c12": "^3.3.4",
-                "chokidar": "^5.0.0",
-                "consola": "^3.4.2",
-                "db0": "^0.3.4",
-                "defu": "^6.1.7",
-                "destr": "^2.0.5",
-                "git-url-parse": "^16.1.0",
-                "h3": "^1.15.11",
-                "hookable": "^5.5.3",
-                "isomorphic-git": "^1.38.9",
-                "jiti": "^2.7.0",
-                "json-schema-to-typescript-lite": "^15.0.0",
-                "mdast-util-to-hast": "^13.2.1",
-                "mdast-util-to-string": "^4.0.0",
-                "micromark": "^4.0.2",
-                "micromark-util-character": "^2.1.1",
-                "micromark-util-chunked": "^2.0.1",
-                "micromark-util-resolve-all": "^2.0.1",
-                "micromark-util-sanitize-uri": "^2.0.1",
-                "micromatch": "^4.0.8",
-                "minimark": "^0.2.0",
-                "minimatch": "^10.2.5",
-                "nuxt-component-meta": "0.18.0",
-                "nypm": "^0.6.8",
-                "ohash": "^2.0.11",
-                "pathe": "^2.0.3",
-                "pkg-types": "^2.3.1",
-                "remark-mdc": "^3.11.1",
-                "scule": "^1.3.0",
-                "shiki": "^4.3.1",
-                "slugify": "^1.6.9",
-                "socket.io-client": "^4.8.3",
-                "std-env": "^4.2.0",
-                "tinyglobby": "^0.2.17",
-                "ufo": "^1.6.4",
-                "unctx": "^2.5.0",
-                "unified": "^11.0.5",
-                "unist-util-stringify-position": "^4.0.0",
-                "unist-util-visit": "^5.1.0",
-                "unplugin": "^3.3.0",
-                "zod": "^3.25.76",
-                "zod-to-json-schema": "^3.25.2"
-            },
-            "engines": {
-                "node": ">= 20.19.0"
-            },
-            "peerDependencies": {
-                "@electric-sql/pglite": "*",
-                "@libsql/client": "*",
-                "@valibot/to-json-schema": "^1.5.0",
-                "better-sqlite3": "^12.5.0",
-                "sqlite3": "*",
-                "valibot": "^1.2.0"
-            },
-            "peerDependenciesMeta": {
-                "@electric-sql/pglite": {
-                    "optional": true
-                },
-                "@libsql/client": {
-                    "optional": true
-                },
-                "@valibot/to-json-schema": {
-                    "optional": true
-                },
-                "better-sqlite3": {
-                    "optional": true
-                },
-                "sqlite3": {
-                    "optional": true
-                },
-                "valibot": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/docus/node_modules/@nuxt/content/node_modules/zod": {
-            "version": "3.25.76",
-            "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-            "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/colinhacks"
-            }
-        },
-        "node_modules/docus/node_modules/estree-walker": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/estree": "^1.0.0"
-            }
-        },
-        "node_modules/docus/node_modules/hookable": {
-            "version": "5.5.3",
-            "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
-            "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
-            "license": "MIT"
-        },
-        "node_modules/docus/node_modules/magic-string": {
-            "version": "0.30.21",
-            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
-            "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@jridgewell/sourcemap-codec": "^1.5.5"
-            }
-        },
-        "node_modules/docus/node_modules/unctx": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/unctx/-/unctx-2.5.0.tgz",
-            "integrity": "sha512-p+Rz9x0R7X+CYDkT+Xg8/GhpcShTlU8n+cf9OtOEf7zEQsNcCZO1dPKNRDqvUTaq+P32PMMkxWHwfrxkqfqAYg==",
-            "license": "MIT",
-            "dependencies": {
-                "acorn": "^8.15.0",
-                "estree-walker": "^3.0.3",
-                "magic-string": "^0.30.21",
-                "unplugin": "^2.3.11"
-            }
-        },
-        "node_modules/docus/node_modules/unctx/node_modules/unplugin": {
-            "version": "2.3.11",
-            "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-2.3.11.tgz",
-            "integrity": "sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==",
-            "license": "MIT",
-            "dependencies": {
-                "@jridgewell/remapping": "^2.3.5",
-                "acorn": "^8.15.0",
-                "picomatch": "^4.0.3",
-                "webpack-virtual-modules": "^0.6.2"
-            },
-            "engines": {
-                "node": ">=18.12.0"
             }
         },
         "node_modules/dom-serializer": {
@@ -10314,9 +10230,9 @@
             "license": "MIT"
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.411",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.411.tgz",
-            "integrity": "sha512-gglkxzokjHfawpGxq75XdBV2/l3BAPzrsMs70qgaZdTW5rpV1tC4MdgJVP9fN126bODA4ZJQkn1wryEzJyQXIg==",
+            "version": "1.5.422",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.422.tgz",
+            "integrity": "sha512-UvA/32XqrLDdZSn7Jllo1AYNcWji/G0d5M0GTViE7KoGBiMunw3a34Sb2KO4ZZyrSEhqsxFoVhWWJshdyfKqJA==",
             "license": "ISC"
         },
         "node_modules/embla-carousel": {
@@ -10635,9 +10551,9 @@
             }
         },
         "node_modules/eslint": {
-            "version": "10.8.1",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.1.tgz",
-            "integrity": "sha512-wqA7W2jbsC/BnV9Iv1UZpKVFkO1AdNoSmYW8NWG4HNOBbkAMvIqDZ27pI2f07dqn583NcIC44ckjAcOXDL1QbQ==",
+            "version": "10.10.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.10.0.tgz",
+            "integrity": "sha512-NPXn6r5zl4uET1DAVPaOwzX3rut4c0wcmw3dWJAfOsTM5+TogXo0DDjz8pwm/hL8cyVNpHqeK4JpN0NjnyFFNw==",
             "license": "MIT",
             "peer": true,
             "workspaces": [
@@ -10649,7 +10565,7 @@
                 "@eslint/config-array": "^0.23.5",
                 "@eslint/config-helpers": "^0.7.0",
                 "@eslint/core": "^1.2.1",
-                "@eslint/plugin-kit": "^0.7.2",
+                "@eslint/plugin-kit": "^0.7.3",
                 "@humanfs/node": "^0.16.6",
                 "@humanwhocodes/module-importer": "^1.0.1",
                 "@humanwhocodes/retry": "^0.4.2",
@@ -10664,7 +10580,7 @@
                 "esquery": "^1.7.0",
                 "esutils": "^2.0.2",
                 "fast-deep-equal": "^3.1.3",
-                "file-entry-cache": "^8.0.0",
+                "file-entry-cache": "11.1.5 || >11.1.6 <12",
                 "find-up": "^5.0.0",
                 "glob-parent": "^6.0.2",
                 "ignore": "^5.2.0",
@@ -10998,9 +10914,9 @@
             }
         },
         "node_modules/express-rate-limit": {
-            "version": "8.6.2",
-            "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.2.tgz",
-            "integrity": "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==",
+            "version": "8.7.0",
+            "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.7.0.tgz",
+            "integrity": "sha512-hOwV7WOxXfjRpAM1DSJWZDXx3GhplwD8IfwuwvogD8i1Qnkgosw/H45s4ZnFAUHDAhPjlY9hLBvJhKmGMyY26g==",
             "license": "MIT",
             "dependencies": {
                 "debug": "^4.4.3",
@@ -11147,9 +11063,9 @@
             }
         },
         "node_modules/fastq": {
-            "version": "1.20.1",
-            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
-            "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+            "version": "1.20.3",
+            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.3.tgz",
+            "integrity": "sha512-XKv5nnLs6nLF71NgiKJLIZFLkPyIEuOselLG7ujZnGrRfQK8HpvY+WqKhAJUAdLomwVHErVS4LfxFlPq0/FTAw==",
             "license": "ISC",
             "dependencies": {
                 "reusify": "^1.0.4"
@@ -11180,16 +11096,13 @@
             }
         },
         "node_modules/file-entry-cache": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
-            "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+            "version": "11.1.5",
+            "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-11.1.5.tgz",
+            "integrity": "sha512-+PFTHITI08JIGhnNpGNI8T8inUpgZfk3GNEqfT9R2zZV2iFXg3CvqzSl/uEhs7TSGujYRELEANyDvS8Fj7+S7Q==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "flat-cache": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=16.0.0"
+                "flat-cache": "^6.1.23"
             }
         },
         "node_modules/file-uri-to-path": {
@@ -11261,17 +11174,15 @@
             }
         },
         "node_modules/flat-cache": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
-            "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+            "version": "6.1.23",
+            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.23.tgz",
+            "integrity": "sha512-f++BY9pTk+983xK1FLzlLpmM0i0z+jHmx3QESGkURMXujQZz1k5wzwX6hjnQ8goaD0B+sYnDK1yZ6MTyZfUaqA==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "flatted": "^3.2.9",
-                "keyv": "^4.5.4"
-            },
-            "engines": {
-                "node": ">=16"
+                "cacheable": "^2.5.0",
+                "flatted": "^3.4.2",
+                "hookified": "^1.15.0"
             }
         },
         "node_modules/flatted": {
@@ -11436,12 +11347,12 @@
             }
         },
         "node_modules/framer-motion": {
-            "version": "13.1.0",
-            "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-13.1.0.tgz",
-            "integrity": "sha512-QSZrF0Id3QGuHJ+OL+9PSY9pk86C8ERFalwAGSchzTm65+ZoGH/RM26lmEARLljcHj2lqhv0jZOOks+EI3COOw==",
+            "version": "13.2.0",
+            "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-13.2.0.tgz",
+            "integrity": "sha512-9E33ebgMaO33w1nN/jEdW8z3/GO483fMi4rqbMG9rt83XgW9QLKRe4NcmJ8s+fQ3O34++UHrIQwlIWGIWTITjA==",
             "license": "MIT",
             "dependencies": {
-                "motion-dom": "^13.0.0",
+                "motion-dom": "^13.2.0",
                 "motion-utils": "^13.0.0",
                 "tslib": "^2.4.0"
             },
@@ -11695,15 +11606,16 @@
             }
         },
         "node_modules/globby": {
-            "version": "16.2.3",
-            "resolved": "https://registry.npmjs.org/globby/-/globby-16.2.3.tgz",
-            "integrity": "sha512-VZX7TV7jmd/pn71vdnLKtgwy1IWqc3KjI9x1/UtPkwoKk5fKrNLY30ltDe3cAM5xruIN7YuuaulFt133jRrKZg==",
+            "version": "16.2.4",
+            "resolved": "https://registry.npmjs.org/globby/-/globby-16.2.4.tgz",
+            "integrity": "sha512-c8B/VNLmxRcmqqenRA9t+9IyOjf9+V6lTxPaUJLqOCONdQkWZ0ETYgX0qbtJqPsgCNusT9MZ5Jeidw8Eb9tn2g==",
             "license": "MIT",
             "dependencies": {
                 "@sindresorhus/merge-streams": "^4.0.0",
                 "fast-glob": "^3.3.3",
                 "ignore": "^7.0.5",
                 "is-path-inside": "^4.0.0",
+                "micromatch": "^4.0.8",
                 "slash": "^5.1.0",
                 "unicorn-magic": "^0.4.0"
             },
@@ -11801,6 +11713,19 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/hashery": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/hashery/-/hashery-1.5.1.tgz",
+            "integrity": "sha512-iZyKG96/JwPz1N55vj2Ie2vXbhu440zfUfJvSwEqEbeLluk7NnapfGqa7LH0mOsnDxTF85Mx8/dyR6HfqcbmbQ==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "hookified": "^1.15.0"
+            },
+            "engines": {
+                "node": ">=20"
             }
         },
         "node_modules/hasown": {
@@ -12150,9 +12075,9 @@
             "license": "MIT"
         },
         "node_modules/hono": {
-            "version": "4.13.3",
-            "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.3.tgz",
-            "integrity": "sha512-r8AO2mYHoLxSHkgafNeC/BXyb2vWRxD3jem4Ts+ptav8oTG5FIRifAjuJEmZI4bSvvc2ns0GxmIYiZnHqN3mMw==",
+            "version": "4.13.7",
+            "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.7.tgz",
+            "integrity": "sha512-c8/gF9ac8Y78/agExVocyLevgR+JlpNB444Py0FSX8pJoPdYUfUzRcXtYEYGwt6l19qIlVZPN5Mfsw9jFShmQQ==",
             "license": "MIT",
             "engines": {
                 "node": ">=16.9.0"
@@ -12163,6 +12088,13 @@
             "resolved": "https://registry.npmjs.org/hookable/-/hookable-6.1.1.tgz",
             "integrity": "sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==",
             "license": "MIT"
+        },
+        "node_modules/hookified": {
+            "version": "1.15.1",
+            "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.15.1.tgz",
+            "integrity": "sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==",
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/html-void-elements": {
             "version": "3.0.0",
@@ -12313,9 +12245,9 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/ignore": {
-            "version": "7.0.6",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
-            "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+            "version": "7.0.8",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.8.tgz",
+            "integrity": "sha512-YYNsSlXBjMk92SKnkwvB5LOVSa6OznlFUGcsvrFgNJbJCd0M1XKeFVRc8ZByeCqz32FivYNHJVooLmdqrmvp/Q==",
             "license": "MIT",
             "engines": {
                 "node": ">= 4"
@@ -12338,9 +12270,9 @@
             }
         },
         "node_modules/impound": {
-            "version": "1.1.7",
-            "resolved": "https://registry.npmjs.org/impound/-/impound-1.1.7.tgz",
-            "integrity": "sha512-v/7sJ+2BX17U5VV9J1H72ExlRtfGoieRpYZG9DTos6gtCbB65C1l0CPehXCXq9phYZn6viphV5XayyZFHi85zg==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/impound/-/impound-1.2.0.tgz",
+            "integrity": "sha512-hbFh2WURN+XQ364SbblzubhEEj/B3qZCe80l/EHXPWM6/kZP2mvOllxwRBBWNxe4gLbqXZL0fxOZwoDCSlJZQw==",
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/trace-mapping": "^0.3.31",
@@ -12398,9 +12330,9 @@
             }
         },
         "node_modules/ip-address": {
-            "version": "10.5.0",
-            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
-            "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
+            "version": "10.7.0",
+            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.7.0.tgz",
+            "integrity": "sha512-BGFsyJd5mpXp3rK6jIdADLNgpJUK1jnjzvYF8lK+VyDab9JAmqN0YOKDdP17HlgKb2+ehPgDc8EtnRLbGCAMhA==",
             "license": "MIT",
             "engines": {
                 "node": ">= 12"
@@ -12753,9 +12685,9 @@
             "license": "ISC"
         },
         "node_modules/isomorphic-git": {
-            "version": "1.41.3",
-            "resolved": "https://registry.npmjs.org/isomorphic-git/-/isomorphic-git-1.41.3.tgz",
-            "integrity": "sha512-5O+pSDz+F8eUqhWHjvoF1kcCYtt9mjja5rHficiNFRAWbYfoiXoPfBKzLTqWyEKoEgLObu4TXthkCmYGpfkiyQ==",
+            "version": "1.41.9",
+            "resolved": "https://registry.npmjs.org/isomorphic-git/-/isomorphic-git-1.41.9.tgz",
+            "integrity": "sha512-WOh4ujm5mznHphzQvwj9bVj+pQpV0oZ8H4lAnh4dSaie+lN/lJ2rb6rNOOcP+2m4z8IOQp186TkEULD28NMBJg==",
             "license": "MIT",
             "dependencies": {
                 "async-lock": "^1.4.1",
@@ -12822,9 +12754,9 @@
             }
         },
         "node_modules/jose": {
-            "version": "6.2.9",
-            "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.9.tgz",
-            "integrity": "sha512-XrchZOFZUl/T3vTwRe8XK+cJrGtMF4th1ARnDfwbBXFKThGhlsxEE4Zu03AD/bjJSt/9jT/mxrOCkJWOg77aPA==",
+            "version": "6.2.12",
+            "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.12.tgz",
+            "integrity": "sha512-9NiFmJEex0sy2Dk58j2UGBSHgUs2ypF9eZSu4L6vjOX3Dp96Sw1F3uL+H+D1sx02jZZdzUT0HgvCy59CuvXcWw==",
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/panva"
@@ -12837,9 +12769,9 @@
             "license": "MIT"
         },
         "node_modules/js-yaml": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-            "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+            "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
             "funding": [
                 {
                     "type": "github",
@@ -12869,13 +12801,6 @@
             "engines": {
                 "node": ">=6"
             }
-        },
-        "node_modules/json-buffer": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-            "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-            "license": "MIT",
-            "peer": true
         },
         "node_modules/json-schema": {
             "version": "0.4.0",
@@ -12960,13 +12885,13 @@
             }
         },
         "node_modules/keyv": {
-            "version": "4.5.4",
-            "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
-            "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+            "version": "5.6.0",
+            "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+            "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "json-buffer": "3.0.1"
+                "@keyv/serialize": "^1.1.1"
             }
         },
         "node_modules/kleur": {
@@ -13432,9 +13357,9 @@
             }
         },
         "node_modules/listhen/node_modules/crossws": {
-            "version": "0.4.10",
-            "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.4.10.tgz",
-            "integrity": "sha512-pz3oubH/dt12KjqsUB0IuXW4nwRDQ583iDsP4555Cpdqx0NoU7pGlWBcayyFI8f/l/idRpgjMEfwuOxSWJYlIA==",
+            "version": "0.4.12",
+            "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.4.12.tgz",
+            "integrity": "sha512-aypfsr6t0uNvkqaZc6zvBfXzC6pLI0/sIulpkV6RwCVtZqG5ebBzv4weImKK0VNCj91Wl9F5j7p5WU4MNrybng==",
             "license": "MIT",
             "peerDependencies": {
                 "srvx": ">=0.11.5"
@@ -13561,9 +13486,9 @@
             }
         },
         "node_modules/magic-string": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-1.2.1.tgz",
-            "integrity": "sha512-vCfXkt3lIJha02CjPT1igeysyHVfCsEpIeD20O+X9aJ2hML3/kKx8E9Iv1FB+aMSAlDOEAtpRWzuooQCrYwdUg==",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-1.2.3.tgz",
+            "integrity": "sha512-Bpb0W2TbLKOZ7vJnOUnVRGq3WL2p+ISV29M6hYPL1AFCpyKZpdr5ytiXoTSSxRVhg8YW7f65+6gbG8WG6PCa/g==",
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/sourcemap-codec": "^1.5.5"
@@ -13605,15 +13530,15 @@
             }
         },
         "node_modules/markdown-exit": {
-            "version": "1.0.0-beta.9",
-            "resolved": "https://registry.npmjs.org/markdown-exit/-/markdown-exit-1.0.0-beta.9.tgz",
-            "integrity": "sha512-5tzrMKMF367amyBly131vm6eGuWRL2DjBqWaFmPzPbLyuxP0XOmyyyroOAIXuBAMF/3kZbbfqOxvW/SotqKqbQ==",
+            "version": "1.1.0-beta.2",
+            "resolved": "https://registry.npmjs.org/markdown-exit/-/markdown-exit-1.1.0-beta.2.tgz",
+            "integrity": "sha512-8CzMGVlFZ4DEfnc8KU+4ycUW2SIOuiXqCHD7z51ecVEi/weyc0f2ylQbCm4KoKuVlTZSuMUMnWT0hTyquZ7anQ==",
             "license": "MIT",
             "dependencies": {
                 "@types/linkify-it": "^5.0.0",
                 "@types/mdurl": "^2.0.0",
                 "entities": "^7.0.0",
-                "linkify-it": "^5.0.0",
+                "linkify-it": "^5.0.1",
                 "mdurl": "^2.0.0",
                 "punycode.js": "^2.3.1",
                 "uc.micro": "^2.1.0"
@@ -14684,9 +14609,9 @@
             "license": "MIT"
         },
         "node_modules/motion-dom": {
-            "version": "13.0.0",
-            "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-13.0.0.tgz",
-            "integrity": "sha512-Xk+SJas70uMAUIApg+m3lZDShxI3LBFHq7mFGbBKoRXc2PVPDyAKmzN64Bbzt4CZdP/CItTiJxWtn4TA0v53Ng==",
+            "version": "13.2.0",
+            "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-13.2.0.tgz",
+            "integrity": "sha512-N6gdSoWRDk0Rh/fVtlqUtLs+fEN3ELFZI3cn3IQE9Mnf3E+Mh8wjO6MstzCOPFh4Yf0L1as5m2eUyYWj8ylVSQ==",
             "license": "MIT",
             "dependencies": {
                 "motion-utils": "^13.0.0"
@@ -14699,9 +14624,9 @@
             "license": "MIT"
         },
         "node_modules/motion-v": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/motion-v/-/motion-v-2.4.0.tgz",
-            "integrity": "sha512-kRDGMAZk3nvdjEO36Wo6pezSEIStGXGhVFiwo1QkUDsUg8mB5igjYPXyece8wtu2DrHhmFfA6Y1nOz07+5QH4A==",
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/motion-v/-/motion-v-2.4.2.tgz",
+            "integrity": "sha512-I3+pa3s1iCtk1hS7En7+ZYH1E165FQHAC4ZRjv6wsQPkd7wqyE+ooOPqal3FXQOCCYesmUs5BS6KLx4Fz83m+A==",
             "license": "MIT",
             "dependencies": {
                 "framer-motion": "^13.1.0",
@@ -14773,12 +14698,32 @@
             "peer": true
         },
         "node_modules/negotiator": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
-            "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.1.0.tgz",
+            "integrity": "sha512-NMPBRMJgiQHjbd8phG3Vebdx4kZ1H121rbl5IkMqeOsahptB9BKo/d7oJ3zTXqTgagn2bWlNSXkh0QUGM31RYg==",
+            "license": "MIT",
+            "dependencies": {
+                "content-type": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/negotiator/node_modules/content-type": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+            "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
             "license": "MIT",
             "engines": {
-                "node": ">= 0.6"
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/nitropack": {
@@ -14880,6 +14825,40 @@
             "integrity": "sha512-aVf4A4hI2w70LnF7GG+7xDQUkliwiXWXFvTjkip4+b64ygDQ2sJPRSKFDHbxn8o0xu9QzPkMuuiWIXyFSE2slA==",
             "license": "MIT"
         },
+        "node_modules/nitropack/node_modules/db0": {
+            "version": "0.3.4",
+            "resolved": "https://registry.npmjs.org/db0/-/db0-0.3.4.tgz",
+            "integrity": "sha512-RiXXi4WaNzPTHEOu8UPQKMooIbqOEyqA1t7Z6MsdxSCeb8iUC9ko3LcmsLmeUt2SM5bctfArZKkRQggKZz7JNw==",
+            "license": "MIT",
+            "peerDependencies": {
+                "@electric-sql/pglite": "*",
+                "@libsql/client": "*",
+                "better-sqlite3": "*",
+                "drizzle-orm": "*",
+                "mysql2": "*",
+                "sqlite3": "*"
+            },
+            "peerDependenciesMeta": {
+                "@electric-sql/pglite": {
+                    "optional": true
+                },
+                "@libsql/client": {
+                    "optional": true
+                },
+                "better-sqlite3": {
+                    "optional": true
+                },
+                "drizzle-orm": {
+                    "optional": true
+                },
+                "mysql2": {
+                    "optional": true
+                },
+                "sqlite3": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/nitropack/node_modules/escape-string-regexp": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
@@ -14953,9 +14932,9 @@
             }
         },
         "node_modules/node-abi": {
-            "version": "3.95.0",
-            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.95.0.tgz",
-            "integrity": "sha512-T9iGctuocf0qIWFFOTxPzjT5q0SILqaBYXt272tlBHvTKC5+3JnkMirLxNJNkXHtFyBjU2Jx+NL4Zipr0B/c6Q==",
+            "version": "3.96.0",
+            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.96.0.tgz",
+            "integrity": "sha512-rebQ/lz7i0EkoLzUVSrKRzA69zMkwLp95kKMWoMDkkM00Suxz0D7zEQPwRml5fQum24mj7bPvmlgLAmu2JCiYg==",
             "license": "MIT",
             "dependencies": {
                 "semver": "^7.3.5"
@@ -15032,9 +15011,9 @@
             "license": "MIT"
         },
         "node_modules/node-releases": {
-            "version": "2.0.53",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.53.tgz",
-            "integrity": "sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==",
+            "version": "2.0.54",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.54.tgz",
+            "integrity": "sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==",
             "license": "MIT",
             "engines": {
                 "node": ">=18"
@@ -15703,43 +15682,41 @@
             }
         },
         "node_modules/nuxt-og-image": {
-            "version": "6.6.0",
-            "resolved": "https://registry.npmjs.org/nuxt-og-image/-/nuxt-og-image-6.6.0.tgz",
-            "integrity": "sha512-PsnLWVf2D3/pmVvQ/7H17qKtFcKJlH0O611XZhpSx5bEwalNY8tbotmHAqlavhRk5KUvCJBUuCE+QCIW3aBE7w==",
+            "version": "6.7.8",
+            "resolved": "https://registry.npmjs.org/nuxt-og-image/-/nuxt-og-image-6.7.8.tgz",
+            "integrity": "sha512-G7Vm+QNZf5LT85BupX0k8xuA+xjXUB/dY4stLuAIdFmv1CeNbnr5SkFGceRk35FHIK66nIim7wgRU4hGmxzH8Q==",
             "license": "MIT",
             "dependencies": {
-                "@clack/prompts": "^1.5.1",
-                "@nuxt/kit": "^4.4.8",
-                "@unocss/config": "^66.7.0",
-                "@unocss/core": "^66.7.0",
-                "@vue/compiler-sfc": "^3.5.35",
+                "@clack/prompts": "^1.7.0",
+                "@nuxt/kit": "^4.5.2",
+                "@vue/compiler-sfc": "^3.5.41",
                 "chrome-launcher": "^1.2.1",
                 "consola": "^3.4.2",
-                "culori": "^4.0.2",
                 "defu": "^6.1.7",
-                "devalue": "^5.8.1",
-                "exsolve": "^1.0.8",
-                "lightningcss": "^1.32.0",
-                "magic-string": "^0.30.21",
-                "magicast": "^0.5.3",
+                "devalue": "^5.9.0",
+                "exsolve": "^1.1.1",
+                "fnv1a-64": "^0.1.2",
+                "lightningcss": "^1.33.0",
+                "magic-string": "^1.1.0",
+                "magicast": "^0.5.4",
                 "mocked-exports": "^0.1.1",
-                "nuxt-site-config": "^4.0.8",
-                "nuxtseo-shared": "^5.2.6",
-                "nypm": "^0.6.6",
+                "nuxt-site-config": "^4.2.0",
+                "nuxtseo-shared": "^5.3.12",
+                "nypm": "^0.6.9",
+                "object-identity": "^0.2.3",
                 "ofetch": "^1.5.1",
                 "ohash": "^2.0.11",
-                "oxc-parser": "^0.135.0",
-                "oxc-walker": "^1.0.0",
+                "oxc-parser": "^0.143.0",
+                "oxc-walker": "^1.1.1",
                 "pathe": "^2.0.3",
                 "pkg-types": "^2.3.1",
                 "radix3": "^1.1.2",
-                "std-env": "^4.1.0",
-                "strip-literal": "^3.1.0",
-                "tinyexec": "^1.2.4",
-                "tinyglobby": "^0.2.17",
+                "std-env": "^4.2.0",
+                "strip-literal": "^4.0.0",
+                "tinyexec": "^1.3.0",
                 "ufo": "^1.6.4",
-                "ultrahtml": "^1.6.0",
-                "unplugin": "^3.0.0"
+                "ultrahtml": "^1.7.0",
+                "unplugin": "^3.3.0"
             },
             "bin": {
                 "nuxt-og-image": "bin/cli.mjs"
@@ -15753,9 +15730,11 @@
             "peerDependencies": {
                 "@resvg/resvg-js": "^2.6.0",
                 "@resvg/resvg-wasm": "^2.6.0",
-                "@takumi-rs/core": "^1.0.0-beta.3",
-                "@takumi-rs/wasm": "^1.0.0-beta.3",
+                "@takumi-rs/core": "^1.0.0-beta.3 || ^2.0.0",
+                "@takumi-rs/wasm": "^1.0.0-beta.3 || ^2.0.0",
                 "@unhead/vue": "^2.0.5 || ^3.0.0",
+                "@unocss/config": "^66.7.5",
+                "@unocss/core": "^66.7.5",
                 "fontless": "^0.2.0",
                 "nitropack": "^2.13.4",
                 "playwright-core": "^1.50.0",
@@ -15777,6 +15756,12 @@
                     "optional": true
                 },
                 "@takumi-rs/wasm": {
+                    "optional": true
+                },
+                "@unocss/config": {
+                    "optional": true
+                },
+                "@unocss/core": {
                     "optional": true
                 },
                 "fontless": {
@@ -15805,41 +15790,10 @@
                 }
             }
         },
-        "node_modules/nuxt-og-image/node_modules/@emnapi/core": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-            "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "@emnapi/wasi-threads": "1.2.1",
-                "tslib": "^2.4.0"
-            }
-        },
-        "node_modules/nuxt-og-image/node_modules/@emnapi/runtime": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-            "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "tslib": "^2.4.0"
-            }
-        },
-        "node_modules/nuxt-og-image/node_modules/@emnapi/wasi-threads": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-            "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "tslib": "^2.4.0"
-            }
-        },
         "node_modules/nuxt-og-image/node_modules/@oxc-parser/binding-android-arm-eabi": {
-            "version": "0.135.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.135.0.tgz",
-            "integrity": "sha512-sHeZItACNcA5WRAWqF6ixriR4GkZDyY10gVgnZU7pXku1DjHFATSqnwZM809jl0gXPHxb6fKzYQCK7bNK5cACQ==",
+            "version": "0.143.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.143.0.tgz",
+            "integrity": "sha512-n9uozULWflPqBtdmI8lAabLqGKNgLVNN0ZH8HfgCwpKGNtzRzauB76jTiW/3YLkcA7N1zskpi9GdVnZuu1SAvg==",
             "cpu": [
                 "arm"
             ],
@@ -15853,9 +15807,9 @@
             }
         },
         "node_modules/nuxt-og-image/node_modules/@oxc-parser/binding-android-arm64": {
-            "version": "0.135.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.135.0.tgz",
-            "integrity": "sha512-wPte+SzgzWWFgMSF8YZDNM+tBXtJg0AXBi7+tU3yS2z1f2Af9kRLZLKuJojADmuD/cZexmnMHHC3SDItTW77Iw==",
+            "version": "0.143.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.143.0.tgz",
+            "integrity": "sha512-9BbdjHETk6O3zH/DDid9IgBtF0GlpLabNKN231uraXpRDSfY+iiZxTP5bk1Z63GBownVdhdINFIeddmMz4MzpQ==",
             "cpu": [
                 "arm64"
             ],
@@ -15869,9 +15823,9 @@
             }
         },
         "node_modules/nuxt-og-image/node_modules/@oxc-parser/binding-darwin-arm64": {
-            "version": "0.135.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.135.0.tgz",
-            "integrity": "sha512-BmKz3lHIsqVos+9aPcdYCT9MG3APoUyM43KlEFhJMWNVDOGG8FKyiFz81Bc+mGz2o0hpuQ3PfXLfVWJrKXjo2g==",
+            "version": "0.143.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.143.0.tgz",
+            "integrity": "sha512-gh+6ecoHUy4/sUcolBl/1qPXKBbYNxFY0Pk0ujgQvINTMSftJY7o4yb8gOkDJPeZeB8+a+u7xTe6umoP8N5HFA==",
             "cpu": [
                 "arm64"
             ],
@@ -15885,9 +15839,9 @@
             }
         },
         "node_modules/nuxt-og-image/node_modules/@oxc-parser/binding-darwin-x64": {
-            "version": "0.135.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.135.0.tgz",
-            "integrity": "sha512-dM8BS+8+Br1fNvmh2QZbGiHaYttwLebRa6J4Uz9vuFzMNmvsdRYwf7993ptOaV0JTrR63AaoVLjX7nhWbijxjQ==",
+            "version": "0.143.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.143.0.tgz",
+            "integrity": "sha512-qd1hl2d+lXgHv/VQ/M9qm8TrMC5T4RqDBwtOnl+1D0QMjwcz+8AaB4JSg8STgeag0GP6a6L74XEGAsrTSJWNzQ==",
             "cpu": [
                 "x64"
             ],
@@ -15901,9 +15855,9 @@
             }
         },
         "node_modules/nuxt-og-image/node_modules/@oxc-parser/binding-freebsd-x64": {
-            "version": "0.135.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.135.0.tgz",
-            "integrity": "sha512-xlZnvvJdR9bGu2pOhvR5hMuKPHCE6Sa9owK5A484mzjHdm75VRV5nCs5w/jkmGODMMTFc+KN7EnZqEieM813kw==",
+            "version": "0.143.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.143.0.tgz",
+            "integrity": "sha512-M5XXcNa7aOqLPKTR41msfghKu2yQ4xWvCm11/gwU0JzOzHNk5sgW//rVEjJ+LO48+VDAMzXTSzurUVxIDKwozw==",
             "cpu": [
                 "x64"
             ],
@@ -15917,9 +15871,9 @@
             }
         },
         "node_modules/nuxt-og-image/node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
-            "version": "0.135.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.135.0.tgz",
-            "integrity": "sha512-PSR8LmBK/H/PQRiN8g7RebQgZX/ntVCrdT/JBfNxE5ezdHG1s2i4rbazsRJYD83TTI1MmgTpC0MGL42PLtskQQ==",
+            "version": "0.143.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.143.0.tgz",
+            "integrity": "sha512-T/GXusuOkPNQhCQCSBbcU/N8j0rAypuDBl1IyFK+lyYT594XsVz80clPC/OtbSSpBGyJxj8uYEfctxVuxVYoww==",
             "cpu": [
                 "arm"
             ],
@@ -15933,9 +15887,9 @@
             }
         },
         "node_modules/nuxt-og-image/node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
-            "version": "0.135.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.135.0.tgz",
-            "integrity": "sha512-I85GJXzfUsigkkk7Ngdz95C217M4FdUi1Z2HrX5UyPmURobwQZ7m2bbUvwFkz4VGZd+lymFGKHvDZ3RQC9qOzA==",
+            "version": "0.143.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.143.0.tgz",
+            "integrity": "sha512-oKu4RcBlXSqo3OC62dp6YTnQaZIurNDpCX3BnAM3+bJxt7s8J2TJKMnC0UYer1qhlRaDCg6wkTaTw+2IlsZ12w==",
             "cpu": [
                 "arm"
             ],
@@ -15949,9 +15903,9 @@
             }
         },
         "node_modules/nuxt-og-image/node_modules/@oxc-parser/binding-linux-arm64-gnu": {
-            "version": "0.135.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.135.0.tgz",
-            "integrity": "sha512-zqEY0npz0g0aGZj/8a5BclunjVDytsBQHYtIC10Gd26HcrLwbVF6YDbqRQjunMGYdSo97u6xOBl05aTDI2diDQ==",
+            "version": "0.143.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.143.0.tgz",
+            "integrity": "sha512-WJBbD186AZmMGaSIhlktC+rPl8L3peCTXAh88Ih9uEvK0en2mPojGyCGYiL6mHtV1RPV3JyfJW5t6n5hh0lXhA==",
             "cpu": [
                 "arm64"
             ],
@@ -15968,9 +15922,9 @@
             }
         },
         "node_modules/nuxt-og-image/node_modules/@oxc-parser/binding-linux-arm64-musl": {
-            "version": "0.135.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.135.0.tgz",
-            "integrity": "sha512-mWAfprP819gQ2qYst1RxgTI8b/z0b29OpoKfRflIXLHde2dZLihQD4g47Onuvtpo5GPIkMYPRlX9QoeZfs/GnQ==",
+            "version": "0.143.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.143.0.tgz",
+            "integrity": "sha512-t1AcYOwEzgceadT4v5e+vaCCb0AncCA3v5AyzfBAz/tMq11qzVccXKzNHtkWdjBsgvTKwRkaUF3QvT4kot8vcQ==",
             "cpu": [
                 "arm64"
             ],
@@ -15987,9 +15941,9 @@
             }
         },
         "node_modules/nuxt-og-image/node_modules/@oxc-parser/binding-linux-ppc64-gnu": {
-            "version": "0.135.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.135.0.tgz",
-            "integrity": "sha512-gri8c2AOmJKJwOux2KTHFBfUaXoJURuVMKhmKEi/2hTF55cQteTDV2XNfTiE5oCC+Tnem1Y4/MWzcyDadtsSag==",
+            "version": "0.143.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.143.0.tgz",
+            "integrity": "sha512-RsnO/NoD8376LMJq8JS8TwI0ieNaFRTuNe2GVJntQg6gwZNMENZsEbknHdVwjpOmxdGLGodcwaGSbAeRr5Bgjw==",
             "cpu": [
                 "ppc64"
             ],
@@ -16006,9 +15960,9 @@
             }
         },
         "node_modules/nuxt-og-image/node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
-            "version": "0.135.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.135.0.tgz",
-            "integrity": "sha512-Y2tkupCG5wo0SxH2rMLG4d4Kmv6DaM3sBp+GuM5lox0S8Za6VxKgQrY2Mut088QQxKkEE89n/4CCCgmw2o0e3Q==",
+            "version": "0.143.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.143.0.tgz",
+            "integrity": "sha512-48fSVfR9TZi5CASZFyv0VC6z6BCoeihFsX031mAD/oSH7d9PYsPgIqza7d9mjP7Z2KTEpTFyH6SIu0Ui6R1vdg==",
             "cpu": [
                 "riscv64"
             ],
@@ -16025,9 +15979,9 @@
             }
         },
         "node_modules/nuxt-og-image/node_modules/@oxc-parser/binding-linux-riscv64-musl": {
-            "version": "0.135.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.135.0.tgz",
-            "integrity": "sha512-xDRJq6i6WTynjeP+ISbDpyH4p9BaJ0wuQcL0lCSDkt9qOXC9dmwpOu1VG/TlwmPI3KpYntmO9nJCuc3TMTsNBA==",
+            "version": "0.143.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.143.0.tgz",
+            "integrity": "sha512-T8CpdD+SfE01DnIOD4HpVxu0ZJOfMJ/VhCvikKfaXAxkZ+9veyLM/D2hpi7Y2hFUyPmVQO3FNZHmYzV/WlVR4g==",
             "cpu": [
                 "riscv64"
             ],
@@ -16044,9 +15998,9 @@
             }
         },
         "node_modules/nuxt-og-image/node_modules/@oxc-parser/binding-linux-s390x-gnu": {
-            "version": "0.135.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.135.0.tgz",
-            "integrity": "sha512-V4MoUuiCRNvihxhIufRxvK+ka013V4joTSK0FAGA1KEjLuNprfH6N/Qw2uxQEVIFuNYMhD/hV6xJ/ptbzlKdHg==",
+            "version": "0.143.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.143.0.tgz",
+            "integrity": "sha512-QLdeMsCcacenPEFsfxnBUDF1y6opyz5+fmOz9bfD5Y7fiGCMupUCuB3KTPQhNwshIG1P9fPqar9MHxuBDd4bwQ==",
             "cpu": [
                 "s390x"
             ],
@@ -16063,9 +16017,9 @@
             }
         },
         "node_modules/nuxt-og-image/node_modules/@oxc-parser/binding-linux-x64-gnu": {
-            "version": "0.135.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.135.0.tgz",
-            "integrity": "sha512-JCFZ7zM7KXOKoPAbK/ZB4wY0M1jxRECiem2UQuiXLjzGqS9+hno7mtX+qyK2F7HWK2xPhyJb+frpcOtk5DKOtg==",
+            "version": "0.143.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.143.0.tgz",
+            "integrity": "sha512-659ujfqLy6k7cuH3sbzhd8b+ztSq+i6E2E9pG78Q0BmHjAExfGIdgc8cGgMdwAozDXeZFHkJ+LXYJdWsaGdgyw==",
             "cpu": [
                 "x64"
             ],
@@ -16082,9 +16036,9 @@
             }
         },
         "node_modules/nuxt-og-image/node_modules/@oxc-parser/binding-linux-x64-musl": {
-            "version": "0.135.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.135.0.tgz",
-            "integrity": "sha512-9jSVS1b3hOV7sdKH4aA2DFfnTz0RgQd0v2BefR+LYbH8yIlmSM22JJZbAAjVeVXmFgUAk3zJQ1tpE/Nd+Vi2YQ==",
+            "version": "0.143.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.143.0.tgz",
+            "integrity": "sha512-/Mw/9j4TfZcnKphPrzOE6t4MMknXadcAAuVUlDRTF/ETWB5xOgQvOJV2Mh9We/bWxZdoxaGAdc+hy4GuYwQ2yQ==",
             "cpu": [
                 "x64"
             ],
@@ -16101,9 +16055,9 @@
             }
         },
         "node_modules/nuxt-og-image/node_modules/@oxc-parser/binding-openharmony-arm64": {
-            "version": "0.135.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.135.0.tgz",
-            "integrity": "sha512-M857ZLBSdn1Uy/SJJz5zh0qGu67B4P9omCgXGBU2LLqTzraX6ZjVNaKq5yW1PDw/LgJXDXR/dbZfgmB310f11Q==",
+            "version": "0.143.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.143.0.tgz",
+            "integrity": "sha512-8rIKWR2BFuifbIK/1XB9wTaSdtuJ25dlE7ZQYDnEwj/2xH2vHsxnvIjHT3ZjSVuLLwGGlSslIG/fbOJ8TV8rTw==",
             "cpu": [
                 "arm64"
             ],
@@ -16116,28 +16070,10 @@
                 "node": "^20.19.0 || >=22.12.0"
             }
         },
-        "node_modules/nuxt-og-image/node_modules/@oxc-parser/binding-wasm32-wasi": {
-            "version": "0.135.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.135.0.tgz",
-            "integrity": "sha512-2w6DVcntQZX9U5RhXtgiWb3FLWFB5EcwI1U8yr3htOCJUJjagN4BFUHz/Y/d9ZsumndZ6ByxxWEtbUZNE1bfFw==",
-            "cpu": [
-                "wasm32"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "@emnapi/core": "1.10.0",
-                "@emnapi/runtime": "1.10.0",
-                "@napi-rs/wasm-runtime": "^1.1.4"
-            },
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
         "node_modules/nuxt-og-image/node_modules/@oxc-parser/binding-win32-arm64-msvc": {
-            "version": "0.135.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.135.0.tgz",
-            "integrity": "sha512-rX1U8+IH2Z37EJjDXKa1iifvUQAdba+vZ4Ewj1iaG5eA/QaSybzclCOwtWa0/5BuUQnnK/T2JHUEFrwhL6Ck2Q==",
+            "version": "0.143.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.143.0.tgz",
+            "integrity": "sha512-5U9kQYMfRRI6Zq7KDxgbIP0RMnKrfn3gLepRMgJuRkPSUALTiRCk9d/uyhb4lGDjUdzwK7mBkKqhLgzBPCmLpQ==",
             "cpu": [
                 "arm64"
             ],
@@ -16151,9 +16087,9 @@
             }
         },
         "node_modules/nuxt-og-image/node_modules/@oxc-parser/binding-win32-ia32-msvc": {
-            "version": "0.135.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.135.0.tgz",
-            "integrity": "sha512-9FAisBbH1QICGAjlJobiuKGd/jOuVmyqniWdQMwTa5SkCl6hhuotBCJf1n46B0flYbSOR5TzfV9HZCWSyb3c/Q==",
+            "version": "0.143.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.143.0.tgz",
+            "integrity": "sha512-25P7AaHk4R88Yv2XH4gToDVmh0cOu+bEURQU10CRrmvgabfRArSGAP5osmwUKeSUHj0VS50upbpbRWWW/m7mHA==",
             "cpu": [
                 "ia32"
             ],
@@ -16167,9 +16103,9 @@
             }
         },
         "node_modules/nuxt-og-image/node_modules/@oxc-parser/binding-win32-x64-msvc": {
-            "version": "0.135.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.135.0.tgz",
-            "integrity": "sha512-wYF+A2AzJ2n7ul6q+Z2G/ia0S2+8cUp0AgWZzoFvF4WmUcl1P7p+o6se1Gdr5wGnWuF0iAMIkGddrjCarNr2yA==",
+            "version": "0.143.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.143.0.tgz",
+            "integrity": "sha512-ORMh3JE1s6V7ySicdRK7vgaDQnn5o+UHg9ct989PlWHbel8O9ARrmWXM6kZjrBMtNucxNayQ8g69G0VfWzhANw==",
             "cpu": [
                 "x64"
             ],
@@ -16183,30 +16119,282 @@
             }
         },
         "node_modules/nuxt-og-image/node_modules/@oxc-project/types": {
-            "version": "0.135.0",
-            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.135.0.tgz",
-            "integrity": "sha512-wR+xRdFkUBMvcAjBJ2q2kcZM6d+DKu2NgoOyxZgYwZdLhmiv6+rnO8PZ/P68kMiZtIKm+pW7zyEJ4kSOs0vo+Q==",
+            "version": "0.143.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.143.0.tgz",
+            "integrity": "sha512-u6JZdLBTLotrNC9Vd6vPssINdzcCzleKAH6EJKImQb7GtYvX5keN2dxkoK44stCc4tffE6QQRtZTXVSzsLUlWA==",
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/Boshen"
             }
         },
-        "node_modules/nuxt-og-image/node_modules/magic-string": {
-            "version": "0.30.21",
-            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
-            "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
-            "license": "MIT",
+        "node_modules/nuxt-og-image/node_modules/lightningcss": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+            "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+            "license": "MPL-2.0",
             "dependencies": {
-                "@jridgewell/sourcemap-codec": "^1.5.5"
+                "detect-libc": "^2.0.3"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            },
+            "optionalDependencies": {
+                "lightningcss-android-arm64": "1.33.0",
+                "lightningcss-darwin-arm64": "1.33.0",
+                "lightningcss-darwin-x64": "1.33.0",
+                "lightningcss-freebsd-x64": "1.33.0",
+                "lightningcss-linux-arm-gnueabihf": "1.33.0",
+                "lightningcss-linux-arm64-gnu": "1.33.0",
+                "lightningcss-linux-arm64-musl": "1.33.0",
+                "lightningcss-linux-x64-gnu": "1.33.0",
+                "lightningcss-linux-x64-musl": "1.33.0",
+                "lightningcss-win32-arm64-msvc": "1.33.0",
+                "lightningcss-win32-x64-msvc": "1.33.0"
+            }
+        },
+        "node_modules/nuxt-og-image/node_modules/lightningcss-android-arm64": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+            "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/nuxt-og-image/node_modules/lightningcss-darwin-arm64": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+            "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/nuxt-og-image/node_modules/lightningcss-darwin-x64": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+            "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/nuxt-og-image/node_modules/lightningcss-freebsd-x64": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+            "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/nuxt-og-image/node_modules/lightningcss-linux-arm-gnueabihf": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+            "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/nuxt-og-image/node_modules/lightningcss-linux-arm64-gnu": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+            "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+            "cpu": [
+                "arm64"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/nuxt-og-image/node_modules/lightningcss-linux-arm64-musl": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+            "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "libc": [
+                "musl"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/nuxt-og-image/node_modules/lightningcss-linux-x64-gnu": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+            "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+            "cpu": [
+                "x64"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/nuxt-og-image/node_modules/lightningcss-linux-x64-musl": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+            "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+            "cpu": [
+                "x64"
+            ],
+            "libc": [
+                "musl"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/nuxt-og-image/node_modules/lightningcss-win32-arm64-msvc": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+            "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/nuxt-og-image/node_modules/lightningcss-win32-x64-msvc": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+            "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
             }
         },
         "node_modules/nuxt-og-image/node_modules/oxc-parser": {
-            "version": "0.135.0",
-            "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.135.0.tgz",
-            "integrity": "sha512-/DaPStu0s2zzNSRRniKyTPM6Z/o+DapOp2JYNKDL8AsgaBGPK2IdZyB87SQjVH+xeQPz+Qr9mrjglfkYgtbVRA==",
+            "version": "0.143.0",
+            "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.143.0.tgz",
+            "integrity": "sha512-ov0NzaDCOInknS7mP1cwKdJERt3utPW8ldjtdUXQ8Ty0GEFD08wk422vCUN0d7pST6kqtV7dxoI9w1Zi0l/9TA==",
             "license": "MIT",
             "dependencies": {
-                "@oxc-project/types": "^0.135.0"
+                "@oxc-project/types": "^0.143.0"
             },
             "engines": {
                 "node": "^20.19.0 || >=22.12.0"
@@ -16215,26 +16403,25 @@
                 "url": "https://github.com/sponsors/Boshen"
             },
             "optionalDependencies": {
-                "@oxc-parser/binding-android-arm-eabi": "0.135.0",
-                "@oxc-parser/binding-android-arm64": "0.135.0",
-                "@oxc-parser/binding-darwin-arm64": "0.135.0",
-                "@oxc-parser/binding-darwin-x64": "0.135.0",
-                "@oxc-parser/binding-freebsd-x64": "0.135.0",
-                "@oxc-parser/binding-linux-arm-gnueabihf": "0.135.0",
-                "@oxc-parser/binding-linux-arm-musleabihf": "0.135.0",
-                "@oxc-parser/binding-linux-arm64-gnu": "0.135.0",
-                "@oxc-parser/binding-linux-arm64-musl": "0.135.0",
-                "@oxc-parser/binding-linux-ppc64-gnu": "0.135.0",
-                "@oxc-parser/binding-linux-riscv64-gnu": "0.135.0",
-                "@oxc-parser/binding-linux-riscv64-musl": "0.135.0",
-                "@oxc-parser/binding-linux-s390x-gnu": "0.135.0",
-                "@oxc-parser/binding-linux-x64-gnu": "0.135.0",
-                "@oxc-parser/binding-linux-x64-musl": "0.135.0",
-                "@oxc-parser/binding-openharmony-arm64": "0.135.0",
-                "@oxc-parser/binding-wasm32-wasi": "0.135.0",
-                "@oxc-parser/binding-win32-arm64-msvc": "0.135.0",
-                "@oxc-parser/binding-win32-ia32-msvc": "0.135.0",
-                "@oxc-parser/binding-win32-x64-msvc": "0.135.0"
+                "@oxc-parser/binding-android-arm-eabi": "0.143.0",
+                "@oxc-parser/binding-android-arm64": "0.143.0",
+                "@oxc-parser/binding-darwin-arm64": "0.143.0",
+                "@oxc-parser/binding-darwin-x64": "0.143.0",
+                "@oxc-parser/binding-freebsd-x64": "0.143.0",
+                "@oxc-parser/binding-linux-arm-gnueabihf": "0.143.0",
+                "@oxc-parser/binding-linux-arm-musleabihf": "0.143.0",
+                "@oxc-parser/binding-linux-arm64-gnu": "0.143.0",
+                "@oxc-parser/binding-linux-arm64-musl": "0.143.0",
+                "@oxc-parser/binding-linux-ppc64-gnu": "0.143.0",
+                "@oxc-parser/binding-linux-riscv64-gnu": "0.143.0",
+                "@oxc-parser/binding-linux-riscv64-musl": "0.143.0",
+                "@oxc-parser/binding-linux-s390x-gnu": "0.143.0",
+                "@oxc-parser/binding-linux-x64-gnu": "0.143.0",
+                "@oxc-parser/binding-linux-x64-musl": "0.143.0",
+                "@oxc-parser/binding-openharmony-arm64": "0.143.0",
+                "@oxc-parser/binding-win32-arm64-msvc": "0.143.0",
+                "@oxc-parser/binding-win32-ia32-msvc": "0.143.0",
+                "@oxc-parser/binding-win32-x64-msvc": "0.143.0"
             }
         },
         "node_modules/nuxt-site-config": {
@@ -16296,18 +16483,18 @@
             }
         },
         "node_modules/nuxt/node_modules/undici": {
-            "version": "8.10.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
-            "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
+            "version": "8.10.2",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.2.tgz",
+            "integrity": "sha512-/y4/bH9YNU5hi9NIrpOuvGXFcxrj3CMrV+/AYpowAYTpHn8gX/XPFjNy766FPoYY0miQhdW977JFWKGNhBdwyQ==",
             "license": "MIT",
             "engines": {
                 "node": ">=22.19.0"
             }
         },
         "node_modules/nuxtseo-shared": {
-            "version": "5.3.12",
-            "resolved": "https://registry.npmjs.org/nuxtseo-shared/-/nuxtseo-shared-5.3.12.tgz",
-            "integrity": "sha512-fD/zlPWIYQ+tM+i9zGfcsPvOzJDgI+kVM7UPztF360wLN7e1fU7xO4Wbmq6bKhxLTboAuloJwYnv8igc7XOc/w==",
+            "version": "5.3.14",
+            "resolved": "https://registry.npmjs.org/nuxtseo-shared/-/nuxtseo-shared-5.3.14.tgz",
+            "integrity": "sha512-kt3IrUILAD4ElsA5+3uroQUHmDLfQkiYWrdXm4Eb/tSm7L0ug2WQc6Okh9m/KtypCVBfwtChrAVMgSyT/VYP5w==",
             "license": "MIT",
             "dependencies": {
                 "@clack/prompts": "^1.7.0",
@@ -16497,16 +16684,16 @@
             }
         },
         "node_modules/open": {
-            "version": "11.0.1",
-            "resolved": "https://registry.npmjs.org/open/-/open-11.0.1.tgz",
-            "integrity": "sha512-NzwMUB6C1D0+Kd+9iMS/H4k+Ck3cTX6Ckyfr/gAGlmvSE1LUQZnEZvWBi4PYmMwH/S5SMeTXnE+9uAz8uF+pWw==",
+            "version": "11.0.2",
+            "resolved": "https://registry.npmjs.org/open/-/open-11.0.2.tgz",
+            "integrity": "sha512-RWqF+pBSkqecEvCKOn8QYhaNdRMJDZRIrlS/7rTDdLHaPcfXGCZ/h8zb413NfvdeAV0MR7T1yJcA34/q+CSm1Q==",
             "license": "MIT",
             "dependencies": {
-                "default-browser": "^5.4.0",
+                "default-browser": "^5.5.1",
                 "define-lazy-prop": "^3.0.0",
                 "is-in-ssh": "^1.0.0",
                 "is-inside-container": "^1.0.0",
-                "powershell-utils": "^0.2.0",
+                "powershell-utils": "^0.2.1",
                 "wsl-utils": "^1.0.0"
             },
             "engines": {
@@ -16848,9 +17035,9 @@
             "license": "ISC"
         },
         "node_modules/picomatch": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
-            "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+            "version": "4.0.7",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+            "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
             "license": "MIT",
             "engines": {
                 "node": ">=12"
@@ -16878,15 +17065,21 @@
             }
         },
         "node_modules/pkg-types": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.1.tgz",
-            "integrity": "sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.2.tgz",
+            "integrity": "sha512-v0sVXzj7oPGysr543YYZLYbcJNJsKikSsp/fFzoxQ12ewY3ZZr7oCPC8y7OlmxfYB3QPvriXmuPD8KZggE1vqg==",
             "license": "MIT",
             "dependencies": {
-                "confbox": "^0.2.4",
-                "exsolve": "^1.0.8",
+                "confbox": "^0.3.0",
+                "exsolve": "^1.1.1",
                 "pathe": "^2.0.3"
             }
+        },
+        "node_modules/pkg-types/node_modules/confbox": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.3.1.tgz",
+            "integrity": "sha512-cKUSoKa8YxFZZSmraVi7onONx3amu77ngK3kGpsYHDH7drPwCRkQE1RYMPlLRrMtnciRj274XNRxcHxnKmDSnA==",
+            "license": "MIT"
         },
         "node_modules/possible-typed-array-names": {
             "version": "1.1.0",
@@ -16898,9 +17091,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.26",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
-            "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+            "version": "8.5.28",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.28.tgz",
+            "integrity": "sha512-RRuzqDtt5Y9h3quz5hWhK+TPnsmVs6WwSU6LkJMeY4HstUEDuYTG8UJSdawMRzmzAtV+KEoG8N3Qg2qLy5vM/A==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -16917,7 +17110,7 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "nanoid": "^3.3.17",
+                "nanoid": "^3.3.18",
                 "picocolors": "^1.1.1",
                 "source-map-js": "^1.2.1"
             },
@@ -16942,12 +17135,12 @@
             }
         },
         "node_modules/postcss-colormin": {
-            "version": "8.0.4",
-            "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-8.0.4.tgz",
-            "integrity": "sha512-iQ8Eh6Fb3FJx32zduprL33D80bPnE9F4nm+EqvvoHvoK72H7XjvH4GzbD7VlIowmtzf96tgtkjZgmQ/bAi/CYA==",
+            "version": "8.0.5",
+            "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-8.0.5.tgz",
+            "integrity": "sha512-U/N+7tkHgHoD24NB6q9k9uFcRfVJRdzVSit0fM0T2L6fvnpUoTIAYgzkyjD56LHEoCoPNfkMcfTB47SW/lNegQ==",
             "license": "MIT",
             "dependencies": {
-                "@colordx/core": "^5.5.0",
+                "@colordx/core": "^5.6.0",
                 "browserslist": "^4.28.8",
                 "caniuse-api": "^4.0.0",
                 "postcss-value-parser": "^4.2.0"
@@ -17003,9 +17196,9 @@
             }
         },
         "node_modules/postcss-discard-empty": {
-            "version": "8.0.4",
-            "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-8.0.4.tgz",
-            "integrity": "sha512-utsxD6q3E9FCwxBRTe5/Jh9ticSOUmfovDfX6zrLuuX8ZfycSkrsqog2ZwGtVVrAS9SMxAhD73QHe9U/gopVJA==",
+            "version": "8.0.5",
+            "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-8.0.5.tgz",
+            "integrity": "sha512-im0QtfNFa6V3SGPrfqzrWYuhzSz1ztWORKsuhZHQbWdKMh0DiNj3pmqBnABbhdKjyeW6nZ1oZYGh4dMc3biyaw==",
             "license": "MIT",
             "engines": {
                 "node": "^22.11.0 || ^24.11.0 || >=26.0"
@@ -17043,9 +17236,9 @@
             }
         },
         "node_modules/postcss-merge-rules": {
-            "version": "8.0.4",
-            "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-8.0.4.tgz",
-            "integrity": "sha512-bppiIHxg0zUCwdt9MVYy6nM2dBgPBJdZPD5Y3Eg61p79JVaNQXTzghQKVcaGX2vi5v2rz9+zydIIFLTxSh1akw==",
+            "version": "8.0.5",
+            "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-8.0.5.tgz",
+            "integrity": "sha512-jz+QaKz4VhjsqTVsJMRuH+EvrX1F9l6kYFuF8g6geVxFoYnPEZN4G+zqCb6zhxOIcc2aeAo38XEl2pOIZi2gBw==",
             "license": "MIT",
             "dependencies": {
                 "browserslist": "^4.28.8",
@@ -17076,12 +17269,12 @@
             }
         },
         "node_modules/postcss-minify-gradients": {
-            "version": "8.0.4",
-            "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-8.0.4.tgz",
-            "integrity": "sha512-78cIzfNlG4uMT1wgh6svmAw/sFwQPZ9JRqq4zxJpcdOMvXQz3Hh1ZBdX5GeBONp0AoqNVQiHZ2VnQeF+HldT/Q==",
+            "version": "8.0.6",
+            "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-8.0.6.tgz",
+            "integrity": "sha512-NsqlG34WSO44NOHVT6m6ZWpN80fK2l5Zt73PMDXBJKT6fO6GPnI0NBi6xIVFr/naej3ukVUlIFQGxb7JGaa9Zg==",
             "license": "MIT",
             "dependencies": {
-                "@colordx/core": "^5.5.0",
+                "@colordx/core": "^5.6.0",
                 "cssnano-utils": "^6.0.4",
                 "postcss-value-parser": "^4.2.0"
             },
@@ -17128,9 +17321,9 @@
             }
         },
         "node_modules/postcss-normalize-charset": {
-            "version": "8.0.4",
-            "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-8.0.4.tgz",
-            "integrity": "sha512-ihNV/Q9V/+Q9NTqgoK4FOwI7ipqJlsaxoTWxkGyCMi4ArLKX8HqLYIqATB/8xhXd9K88PCXqdR8218u9uuyc4w==",
+            "version": "8.0.5",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-8.0.5.tgz",
+            "integrity": "sha512-l0L1rIe9YHbLaf4xfL2pkkQV3gq/QIy8D0bjsaHYdGVgR+eQk7IBp3dUdIKe6XuG7DzFiCwJn248nvAFAi5CjA==",
             "license": "MIT",
             "engines": {
                 "node": "^22.11.0 || ^24.11.0 || >=26.0"
@@ -17246,9 +17439,9 @@
             }
         },
         "node_modules/postcss-normalize-whitespace": {
-            "version": "8.0.4",
-            "resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-8.0.4.tgz",
-            "integrity": "sha512-LdEzfN2xKS52Hn3iGK4szK8E9d/lCkcrEMsxi4wY5ibXyKDyNmQW+YMlPX8C0uYhdfeFHQLktPOkXJGUZjJDUw==",
+            "version": "8.0.5",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-8.0.5.tgz",
+            "integrity": "sha512-xuFovful3vVIA9fWWmAL2pG1Qr95Udj2MrLgjU50C6r+Xnh3s6t2BN1xXQ8lnCOCAtzMvMpPWYlnAh4nSv5VEQ==",
             "license": "MIT",
             "dependencies": {
                 "postcss-value-parser": "^4.2.0"
@@ -17261,9 +17454,9 @@
             }
         },
         "node_modules/postcss-ordered-values": {
-            "version": "8.0.4",
-            "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-8.0.4.tgz",
-            "integrity": "sha512-hJ8elrQlYgAynaap0275AhUWTq8+aeWRjkKfRTT/id2AAttjbUWvPQUgzEnANU3KHHDdna86KyNrdk4wslGZNQ==",
+            "version": "8.0.5",
+            "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-8.0.5.tgz",
+            "integrity": "sha512-aDL7nPR7w1foUqo4rN6QY1Kr45+SYELnmUg5taZehh7FfFdxQmUjbuOOBuffIXjiHV45zqgFHCb4azsWW19jyw==",
             "license": "MIT",
             "dependencies": {
                 "cssnano-utils": "^6.0.4",
@@ -17277,9 +17470,9 @@
             }
         },
         "node_modules/postcss-reduce-initial": {
-            "version": "8.0.4",
-            "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-8.0.4.tgz",
-            "integrity": "sha512-6SK1CZN9tmVHXhFA+Up7aNjJzIYKgo9I4yHluQKoO8tIa5iGc88x8BiJmMDUvrDtYgt3IZIruS3AGCAdQMAY9Q==",
+            "version": "8.0.5",
+            "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-8.0.5.tgz",
+            "integrity": "sha512-Bh5d7zjH1Ai9LzJ1qULUZIaC18cniD+wA6gFlOPglMxJRC7meXbuPvpJ/zHQGg5QKwQgit++XQhDTiEIhCk8Ow==",
             "license": "MIT",
             "dependencies": {
                 "browserslist": "^4.28.8",
@@ -17308,9 +17501,9 @@
             }
         },
         "node_modules/postcss-selector-parser": {
-            "version": "7.1.5",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.5.tgz",
-            "integrity": "sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw==",
+            "version": "7.1.6",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.6.tgz",
+            "integrity": "sha512-7qASPzhKF2l2KLboRZux8CCTRMdGiV08vWmyKzPz22qZ7ZjQBOeY7rNzNoCLSUiftJ7HUq0GERHmxw/t0dCdMw==",
             "license": "MIT",
             "dependencies": {
                 "cssesc": "^3.0.0",
@@ -17321,13 +17514,13 @@
             }
         },
         "node_modules/postcss-svgo": {
-            "version": "8.0.5",
-            "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-8.0.5.tgz",
-            "integrity": "sha512-8B5r9VfLVD2lANKxDi4FXeP2MX6NdaGIQwaMVXXy5DhzAPO3CdHqPYqknF63y7tuQLB+rSvYyNltW/tHHg4fAg==",
+            "version": "8.0.6",
+            "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-8.0.6.tgz",
+            "integrity": "sha512-auQHNmduFFHzz1sWYM3sroW7IDMzxshlLjnwAALfkrAgPegHFats+jMK6BRCcdIulxPmqXFSQvgoAX4vw8I59g==",
             "license": "MIT",
             "dependencies": {
                 "postcss-value-parser": "^4.2.0",
-                "svgo": "^4.0.2"
+                "svgo": "^4.1.0"
             },
             "engines": {
                 "node": "^22.11.0 || ^24.11.0 || >=26.0"
@@ -17358,9 +17551,9 @@
             "license": "MIT"
         },
         "node_modules/powershell-utils": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.2.0.tgz",
-            "integrity": "sha512-ZlsFlG7MtSFCoc5xreOvBAozCJ6Pf06opgJjh9ONEv418xpZSAzNjstD36C6+JwOnfSqOW/9uDkqKjezTdxZhw==",
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.2.1.tgz",
+            "integrity": "sha512-C+y9x90UElAddDZmV4qOx9W53B61PO7cIqWz2dQsWlwswuq4mr8NEwytdGKboYbQlGZ3awrkTeNvcZiZNHnQ8A==",
             "license": "MIT",
             "engines": {
                 "node": ">=20"
@@ -17407,9 +17600,9 @@
             }
         },
         "node_modules/pretty-bytes": {
-            "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-7.1.1.tgz",
-            "integrity": "sha512-X+vn9z8nOFZQlxOLmfJ0iKDdMD7jYTsTW12OAlCpdoE3Igik6L37pugIZi+N3usuyp5McfgKPWi12q3zvHLeGQ==",
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-7.1.3.tgz",
+            "integrity": "sha512-U2KZ675nqba6XSBppSjU2pRgc9Ffx9+uUtd/RTWYmOawVkZuUbBYuwdtFZQmLv+yMgQ2TQxWWuOpyNje67J9tg==",
             "license": "MIT",
             "engines": {
                 "node": ">=20"
@@ -17580,9 +17773,9 @@
             }
         },
         "node_modules/prosemirror-transform": {
-            "version": "1.12.0",
-            "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.12.0.tgz",
-            "integrity": "sha512-GxboyN4AMIsoHNtz5uf2r2Ru551i5hWeCMD6E2Ib4Eogqoub0NflniaBPVQ4MrGE5yZ8JV9tUHg9qcZTTrcN4w==",
+            "version": "1.12.1",
+            "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.12.1.tgz",
+            "integrity": "sha512-t4F5615FycnCqsX7ShTUs8+jfnwcf46kuFRvSl/3qFx2QTZ4DjgowesLHQXcFP7G//TjesqZG3WtgL7vdyVJyA==",
             "license": "MIT",
             "dependencies": {
                 "prosemirror-model": "^1.21.0"
@@ -17646,6 +17839,26 @@
             "engines": {
                 "node": ">=6"
             }
+        },
+        "node_modules/qified": {
+            "version": "0.10.1",
+            "resolved": "https://registry.npmjs.org/qified/-/qified-0.10.1.tgz",
+            "integrity": "sha512-+Owyggi9IxT1ePKGafcI87ubSmxol6smwJ+RAHDQlx9+9cPwFWDiKFFCPuWhr9ignlGpZ9vDQLw67N4dcTVFEA==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "hookified": "^2.1.1"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/qified/node_modules/hookified": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/hookified/-/hookified-2.2.0.tgz",
+            "integrity": "sha512-p/LgFzRN5FeoD3DLS6bkUapeye6E4SI6yJs6KetENd18S+FBthqYq2amJUWpt5z0EQwwHemidjY5OqJGEKm5uA==",
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/qs": {
             "version": "6.16.0",
@@ -17755,12 +17968,12 @@
             "license": "ISC"
         },
         "node_modules/rc9": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/rc9/-/rc9-3.0.1.tgz",
-            "integrity": "sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/rc9/-/rc9-3.1.0.tgz",
+            "integrity": "sha512-ufjkNVzbRHKcCOmTahZkmVsyc3W+MSk3jY03m+a7tGHkIsdVMG9l10/3HvFbWkkKzY5VFp3pkRsIo/UYgmFL7Q==",
             "license": "MIT",
             "dependencies": {
-                "defu": "^6.1.6",
+                "defu": "^6.1.7",
                 "destr": "^2.0.5"
             }
         },
@@ -18185,12 +18398,12 @@
             }
         },
         "node_modules/rolldown": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.4.tgz",
-            "integrity": "sha512-rSr7irW0K7QRWzjdJXqZowkcRdDtjRduh43rBltnVKd0VFq839l1lJoDvGJb6gl7+4rTTCrPWu+YfujUL8Ug7w==",
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.7.tgz",
+            "integrity": "sha512-g0EtLvBjTUB7jhyV0S/TCup3v/XSVl45vUIGbOGU4QPiyjTenCe4mKuFvW9fEgYmS2Fo42AUssRmNuMziXdrig==",
             "license": "MIT",
             "dependencies": {
-                "@oxc-project/types": "=0.144.0",
+                "@oxc-project/types": "=0.148.0",
                 "@rolldown/pluginutils": "^1.0.0"
             },
             "bin": {
@@ -18200,20 +18413,21 @@
                 "node": "^20.19.0 || >=22.12.0"
             },
             "optionalDependencies": {
-                "@rolldown/binding-android-arm64": "1.2.4",
-                "@rolldown/binding-darwin-arm64": "1.2.4",
-                "@rolldown/binding-darwin-x64": "1.2.4",
-                "@rolldown/binding-freebsd-x64": "1.2.4",
-                "@rolldown/binding-linux-arm-gnueabihf": "1.2.4",
-                "@rolldown/binding-linux-arm64-gnu": "1.2.4",
-                "@rolldown/binding-linux-arm64-musl": "1.2.4",
-                "@rolldown/binding-linux-ppc64-gnu": "1.2.4",
-                "@rolldown/binding-linux-s390x-gnu": "1.2.4",
-                "@rolldown/binding-linux-x64-gnu": "1.2.4",
-                "@rolldown/binding-linux-x64-musl": "1.2.4",
-                "@rolldown/binding-openharmony-arm64": "1.2.4",
-                "@rolldown/binding-win32-arm64-msvc": "1.2.4",
-                "@rolldown/binding-win32-x64-msvc": "1.2.4"
+                "@rolldown/binding-android-arm-eabi": "1.2.7",
+                "@rolldown/binding-android-arm64": "1.2.7",
+                "@rolldown/binding-darwin-arm64": "1.2.7",
+                "@rolldown/binding-darwin-x64": "1.2.7",
+                "@rolldown/binding-freebsd-x64": "1.2.7",
+                "@rolldown/binding-linux-arm-gnueabihf": "1.2.7",
+                "@rolldown/binding-linux-arm64-gnu": "1.2.7",
+                "@rolldown/binding-linux-arm64-musl": "1.2.7",
+                "@rolldown/binding-linux-ppc64-gnu": "1.2.7",
+                "@rolldown/binding-linux-s390x-gnu": "1.2.7",
+                "@rolldown/binding-linux-x64-gnu": "1.2.7",
+                "@rolldown/binding-linux-x64-musl": "1.2.7",
+                "@rolldown/binding-openharmony-arm64": "1.2.7",
+                "@rolldown/binding-win32-arm64-msvc": "1.2.7",
+                "@rolldown/binding-win32-x64-msvc": "1.2.7"
             }
         },
         "node_modules/rolldown-string": {
@@ -18240,18 +18454,18 @@
             }
         },
         "node_modules/rolldown/node_modules/@oxc-project/types": {
-            "version": "0.144.0",
-            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.144.0.tgz",
-            "integrity": "sha512-nuhZIOLuI6TFQ32I/WnUx+SCPY7SdSKwgnFHydAuoS1+Z4BRcaP+RRJmGzl9lw+0OFF7UmaESf7KQRXaNLHypg==",
+            "version": "0.148.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.148.0.tgz",
+            "integrity": "sha512-Nm4s/jB+4FpFsPhWGEC4h7rzksesmtnMXomo6rCMcg/b8zLQuOziRgkCS1fxDCXOlJB/6Q8oABOZ/OP6RIPj9A==",
             "license": "MIT",
             "funding": {
-                "url": "https://github.com/sponsors/Boshen"
+                "url": "https://github.com/sponsors/oxc-project"
             }
         },
         "node_modules/rollup": {
-            "version": "4.62.4",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.4.tgz",
-            "integrity": "sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==",
+            "version": "4.63.1",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.63.1.tgz",
+            "integrity": "sha512-3Df9jsstwhccuEfmAMi9l8XUh/GOkVObmFTU7CCVBysEbcOZLl84jCtaAZMcPiMz2EGKsATzQcU+Xr3n/wU6cg==",
             "license": "MIT",
             "dependencies": {
                 "@types/estree": "1.0.9"
@@ -18265,31 +18479,31 @@
             },
             "optionalDependencies": {
                 "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
-                "@rollup/rollup-android-arm-eabi": "4.62.4",
-                "@rollup/rollup-android-arm64": "4.62.4",
-                "@rollup/rollup-darwin-arm64": "4.62.4",
-                "@rollup/rollup-darwin-x64": "4.62.4",
-                "@rollup/rollup-freebsd-arm64": "4.62.4",
-                "@rollup/rollup-freebsd-x64": "4.62.4",
-                "@rollup/rollup-linux-arm-gnueabihf": "4.62.4",
-                "@rollup/rollup-linux-arm-musleabihf": "4.62.4",
-                "@rollup/rollup-linux-arm64-gnu": "4.62.4",
-                "@rollup/rollup-linux-arm64-musl": "4.62.4",
-                "@rollup/rollup-linux-loong64-gnu": "4.62.4",
-                "@rollup/rollup-linux-loong64-musl": "4.62.4",
-                "@rollup/rollup-linux-ppc64-gnu": "4.62.4",
-                "@rollup/rollup-linux-ppc64-musl": "4.62.4",
-                "@rollup/rollup-linux-riscv64-gnu": "4.62.4",
-                "@rollup/rollup-linux-riscv64-musl": "4.62.4",
-                "@rollup/rollup-linux-s390x-gnu": "4.62.4",
-                "@rollup/rollup-linux-x64-gnu": "4.62.4",
-                "@rollup/rollup-linux-x64-musl": "4.62.4",
-                "@rollup/rollup-openbsd-x64": "4.62.4",
-                "@rollup/rollup-openharmony-arm64": "4.62.4",
-                "@rollup/rollup-win32-arm64-msvc": "4.62.4",
-                "@rollup/rollup-win32-ia32-msvc": "4.62.4",
-                "@rollup/rollup-win32-x64-gnu": "4.62.4",
-                "@rollup/rollup-win32-x64-msvc": "4.62.4",
+                "@rollup/rollup-android-arm-eabi": "4.63.1",
+                "@rollup/rollup-android-arm64": "4.63.1",
+                "@rollup/rollup-darwin-arm64": "4.63.1",
+                "@rollup/rollup-darwin-x64": "4.63.1",
+                "@rollup/rollup-freebsd-arm64": "4.63.1",
+                "@rollup/rollup-freebsd-x64": "4.63.1",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.63.1",
+                "@rollup/rollup-linux-arm-musleabihf": "4.63.1",
+                "@rollup/rollup-linux-arm64-gnu": "4.63.1",
+                "@rollup/rollup-linux-arm64-musl": "4.63.1",
+                "@rollup/rollup-linux-loong64-gnu": "4.63.1",
+                "@rollup/rollup-linux-loong64-musl": "4.63.1",
+                "@rollup/rollup-linux-ppc64-gnu": "4.63.1",
+                "@rollup/rollup-linux-ppc64-musl": "4.63.1",
+                "@rollup/rollup-linux-riscv64-gnu": "4.63.1",
+                "@rollup/rollup-linux-riscv64-musl": "4.63.1",
+                "@rollup/rollup-linux-s390x-gnu": "4.63.1",
+                "@rollup/rollup-linux-x64-gnu": "4.63.1",
+                "@rollup/rollup-linux-x64-musl": "4.63.1",
+                "@rollup/rollup-openbsd-x64": "4.63.1",
+                "@rollup/rollup-openharmony-arm64": "4.63.1",
+                "@rollup/rollup-win32-arm64-msvc": "4.63.1",
+                "@rollup/rollup-win32-ia32-msvc": "4.63.1",
+                "@rollup/rollup-win32-x64-gnu": "4.63.1",
+                "@rollup/rollup-win32-x64-msvc": "4.63.1",
                 "fsevents": "~2.3.2"
             }
         },
@@ -18475,18 +18689,18 @@
             }
         },
         "node_modules/serialize-javascript": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.1.0.tgz",
-            "integrity": "sha512-RNEqWOyhhUQYN9V1GfHwu9AR/g+NTciH6Z5u3/no6X3/w+04J2lVDL+svFQVXgXrEGBMG2puMVN3gq2SNGuTGw==",
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.1.1.tgz",
+            "integrity": "sha512-k3CMsaIvvdSwm8oLB4MXSl0wH2/cwlH7xGcnRd2DaeRmBkbzYmyT8j0tsX60DwD1eRwHTpNpH8ljKu9oUT1MeQ==",
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=20.0.0"
             }
         },
         "node_modules/seroval": {
-            "version": "1.6.2",
-            "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.6.2.tgz",
-            "integrity": "sha512-mPT+SD2TrlB6wvte1KkYOYUkubaTbd6pZ/6Kk3C9nxzrHmCZyhxOO7XGAeL7f+yLKZglzGtM9odUVvg/EhO+vQ==",
+            "version": "1.6.4",
+            "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.6.4.tgz",
+            "integrity": "sha512-LErWMNS2RRFdu2RMA5u/PA59/IWs0XsikyEXGQ2/36iEWFrdG0ABmg17E17cikrv76891kOAMq3TkTFXpwAHXw==",
             "license": "MIT",
             "engines": {
                 "node": ">=10"
@@ -18564,9 +18778,9 @@
             }
         },
         "node_modules/sharp": {
-            "version": "0.35.3",
-            "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz",
-            "integrity": "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==",
+            "version": "0.35.4",
+            "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.4.tgz",
+            "integrity": "sha512-n++8XWcj+jCOr2IOl7h8LbKnGBDY4aPbmprMONBNFdn0ImXqpGVv5zliDs0V9HbmbCQLpbuo2ej9rAoOQTvMDA==",
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
@@ -18581,31 +18795,31 @@
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-darwin-arm64": "0.35.3",
-                "@img/sharp-darwin-x64": "0.35.3",
-                "@img/sharp-freebsd-wasm32": "0.35.3",
-                "@img/sharp-libvips-darwin-arm64": "1.3.2",
-                "@img/sharp-libvips-darwin-x64": "1.3.2",
-                "@img/sharp-libvips-linux-arm": "1.3.2",
-                "@img/sharp-libvips-linux-arm64": "1.3.2",
-                "@img/sharp-libvips-linux-ppc64": "1.3.2",
-                "@img/sharp-libvips-linux-riscv64": "1.3.2",
-                "@img/sharp-libvips-linux-s390x": "1.3.2",
-                "@img/sharp-libvips-linux-x64": "1.3.2",
-                "@img/sharp-libvips-linuxmusl-arm64": "1.3.2",
-                "@img/sharp-libvips-linuxmusl-x64": "1.3.2",
-                "@img/sharp-linux-arm": "0.35.3",
-                "@img/sharp-linux-arm64": "0.35.3",
-                "@img/sharp-linux-ppc64": "0.35.3",
-                "@img/sharp-linux-riscv64": "0.35.3",
-                "@img/sharp-linux-s390x": "0.35.3",
-                "@img/sharp-linux-x64": "0.35.3",
-                "@img/sharp-linuxmusl-arm64": "0.35.3",
-                "@img/sharp-linuxmusl-x64": "0.35.3",
-                "@img/sharp-webcontainers-wasm32": "0.35.3",
-                "@img/sharp-win32-arm64": "0.35.3",
-                "@img/sharp-win32-ia32": "0.35.3",
-                "@img/sharp-win32-x64": "0.35.3"
+                "@img/sharp-darwin-arm64": "0.35.4",
+                "@img/sharp-darwin-x64": "0.35.4",
+                "@img/sharp-freebsd-wasm32": "0.35.4",
+                "@img/sharp-libvips-darwin-arm64": "1.3.3",
+                "@img/sharp-libvips-darwin-x64": "1.3.3",
+                "@img/sharp-libvips-linux-arm": "1.3.3",
+                "@img/sharp-libvips-linux-arm64": "1.3.3",
+                "@img/sharp-libvips-linux-ppc64": "1.3.3",
+                "@img/sharp-libvips-linux-riscv64": "1.3.3",
+                "@img/sharp-libvips-linux-s390x": "1.3.3",
+                "@img/sharp-libvips-linux-x64": "1.3.3",
+                "@img/sharp-libvips-linuxmusl-arm64": "1.3.3",
+                "@img/sharp-libvips-linuxmusl-x64": "1.3.3",
+                "@img/sharp-linux-arm": "0.35.4",
+                "@img/sharp-linux-arm64": "0.35.4",
+                "@img/sharp-linux-ppc64": "0.35.4",
+                "@img/sharp-linux-riscv64": "0.35.4",
+                "@img/sharp-linux-s390x": "0.35.4",
+                "@img/sharp-linux-x64": "0.35.4",
+                "@img/sharp-linuxmusl-arm64": "0.35.4",
+                "@img/sharp-linuxmusl-x64": "0.35.4",
+                "@img/sharp-webcontainers-wasm32": "0.35.4",
+                "@img/sharp-win32-arm64": "0.35.4",
+                "@img/sharp-win32-ia32": "0.35.4",
+                "@img/sharp-win32-x64": "0.35.4"
             },
             "peerDependenciesMeta": {
                 "@types/node": {
@@ -18955,9 +19169,9 @@
             }
         },
         "node_modules/srvx": {
-            "version": "0.12.5",
-            "resolved": "https://registry.npmjs.org/srvx/-/srvx-0.12.5.tgz",
-            "integrity": "sha512-IuvtDNQg5EIwv3c6dleyau7u8hCyGQ7D6+V/QM799Aud07z0wCUcurKLTRfyG33C8oUY+UWcVBFkfHMcbtmRLA==",
+            "version": "0.12.8",
+            "resolved": "https://registry.npmjs.org/srvx/-/srvx-0.12.8.tgz",
+            "integrity": "sha512-7k9HoDhluTlD7UJ+F+OopZoPZXB2J8f/5nW2VMLaB8KsSlZlRQxyyoX0hWEQCxB+F+3ZvB5QX3LqB6xSBRfxQQ==",
             "license": "MIT",
             "optional": true,
             "bin": {
@@ -18989,9 +19203,9 @@
             "license": "MIT"
         },
         "node_modules/streamx": {
-            "version": "2.28.0",
-            "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.0.tgz",
-            "integrity": "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==",
+            "version": "2.28.1",
+            "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.1.tgz",
+            "integrity": "sha512-zEzXb0s5Cds7tqMH6rhZ05lcJydCWiQPEwiNngVqzsxCc962vLY4Uw+mW7od8kDH258k2Uz/JrOkdIAAhSh9VA==",
             "license": "MIT",
             "dependencies": {
                 "events-universal": "^1.0.0",
@@ -19133,22 +19347,16 @@
             }
         },
         "node_modules/strip-literal": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
-            "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-4.0.0.tgz",
+            "integrity": "sha512-PaqAvfUZKBwc/SLmNZtHmzK+v19Z4O4eS3cKPeGvbIv/U3pnyEq4Tuw3/4v/FwfM8VQaEawsyCcOQ0P+kpwWWw==",
             "license": "MIT",
             "dependencies": {
-                "js-tokens": "^9.0.1"
+                "js-tokens": "^10.0.0"
             },
             "funding": {
                 "url": "https://github.com/sponsors/antfu"
             }
-        },
-        "node_modules/strip-literal/node_modules/js-tokens": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
-            "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
-            "license": "MIT"
         },
         "node_modules/structured-clone-es": {
             "version": "2.0.1",
@@ -19197,18 +19405,18 @@
             }
         },
         "node_modules/svgo": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.2.tgz",
-            "integrity": "sha512-ekx94z1rRc5LDi6oSUaeRnYhd0UOJxdtQCL2rF8xpWxD3TPAsISWOrxezqGovqS38GRZOdpDfvQe3ts6F7nsng==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.1.0.tgz",
+            "integrity": "sha512-bkxnTg1kSU0guhIBmibA6UUhrQmPVA1XsQLN+ylCd+UWzbnLkySOcXpyk1mrl05f+pcaCx2eHb+sp6BgMZWX+Q==",
             "license": "MIT",
             "dependencies": {
                 "commander": "^11.1.0",
-                "css-select": "^5.1.0",
+                "css-select": "^6.0.0",
                 "css-tree": "^3.0.1",
-                "css-what": "^6.1.0",
+                "css-what": "^7.0.0",
                 "csso": "^5.0.5",
                 "picocolors": "^1.1.1",
-                "sax": "^1.5.0"
+                "sax": "1.6.1"
             },
             "bin": {
                 "svgo": "bin/svgo.js"
@@ -19367,9 +19575,9 @@
             }
         },
         "node_modules/tar-stream": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
-            "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.1.tgz",
+            "integrity": "sha512-nqsEO8zLZJvrOMdEwkA0QdCLFbetHMn95Zqu4fKwX+hkaTWJPZZOrxx/PwtxoK0MMGQmBQNRW3CPs8IFYQz4cQ==",
             "license": "MIT",
             "dependencies": {
                 "b4a": "^1.6.4",
@@ -19397,9 +19605,9 @@
             }
         },
         "node_modules/terser": {
-            "version": "5.50.0",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.50.0.tgz",
-            "integrity": "sha512-CN9BVxWhgS/hRxtUMjtC2uRWSTcSfQFHMDWma6sKKfIivCD91sM+FOPfvwoaRMqCSrUpe1nv3jDamd9eEQ4y+w==",
+            "version": "5.51.2",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.51.2.tgz",
+            "integrity": "sha512-bWnjSNscmuI+GJze6ZupnHP8G/cTcsJF+bXCeQknk2SHQsgbNJnLrqiH9jZ2W4STPVXH2mDKKRX3iwPhc9Cn/Q==",
             "license": "BSD-2-Clause",
             "dependencies": {
                 "@jridgewell/source-map": "^0.3.3",
@@ -19451,9 +19659,9 @@
             }
         },
         "node_modules/tinyexec": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
-            "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.1.tgz",
+            "integrity": "sha512-GCvB3aoys96IuDFBMcTB46JOR6mdMtAToqwiW8JlWhsoh1mhHi/xn9ss/Dg7N555GiJyEt2qzoG/NHCwM6h1EA==",
             "license": "MIT",
             "engines": {
                 "node": ">=18"
@@ -19607,9 +19815,9 @@
             }
         },
         "node_modules/type-fest": {
-            "version": "5.8.0",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.8.0.tgz",
-            "integrity": "sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==",
+            "version": "5.9.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.9.0.tgz",
+            "integrity": "sha512-yANm3Jr3GiJ1qgJlxGAVxTOIcEOk1rhQHamlXtnrCK7EHP4HeM9OGxtMg/W7HFdrVzw/ZWJKGVIJusVH85sLtw==",
             "license": "(MIT OR CC0-1.0)",
             "dependencies": {
                 "tagged-tag": "^1.0.0"
@@ -19724,67 +19932,6 @@
             "integrity": "sha512-2xRd0VHoAQE4M+vF/DvFFB7pUV0ZxTW1TLi7lHQWnF/Sb5TPeEUV/l+hxcNnGO00ZXGnR0voCMmYRKQf+rvJ2g==",
             "license": "MIT"
         },
-        "node_modules/unconfig": {
-            "version": "7.5.0",
-            "resolved": "https://registry.npmjs.org/unconfig/-/unconfig-7.5.0.tgz",
-            "integrity": "sha512-oi8Qy2JV4D3UQ0PsopR28CzdQ3S/5A1zwsUwp/rosSbfhJ5z7b90bIyTwi/F7hCLD4SGcZVjDzd4XoUQcEanvA==",
-            "license": "MIT",
-            "dependencies": {
-                "@quansync/fs": "^1.0.0",
-                "defu": "^6.1.4",
-                "jiti": "^2.6.1",
-                "quansync": "^1.0.0",
-                "unconfig-core": "7.5.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/antfu"
-            }
-        },
-        "node_modules/unconfig-core": {
-            "version": "7.5.0",
-            "resolved": "https://registry.npmjs.org/unconfig-core/-/unconfig-core-7.5.0.tgz",
-            "integrity": "sha512-Su3FauozOGP44ZmKdHy2oE6LPjk51M/TRRjHv2HNCWiDvfvCoxC2lno6jevMA91MYAdCdwP05QnWdWpSbncX/w==",
-            "license": "MIT",
-            "dependencies": {
-                "@quansync/fs": "^1.0.0",
-                "quansync": "^1.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/antfu"
-            }
-        },
-        "node_modules/unconfig-core/node_modules/quansync": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/quansync/-/quansync-1.0.0.tgz",
-            "integrity": "sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA==",
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://github.com/sponsors/antfu"
-                },
-                {
-                    "type": "individual",
-                    "url": "https://github.com/sponsors/sxzz"
-                }
-            ],
-            "license": "MIT"
-        },
-        "node_modules/unconfig/node_modules/quansync": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/quansync/-/quansync-1.0.0.tgz",
-            "integrity": "sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA==",
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://github.com/sponsors/antfu"
-                },
-                {
-                    "type": "individual",
-                    "url": "https://github.com/sponsors/sxzz"
-                }
-            ],
-            "license": "MIT"
-        },
         "node_modules/uncrypto": {
             "version": "0.1.3",
             "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
@@ -19792,9 +19939,9 @@
             "license": "MIT"
         },
         "node_modules/unctx": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/unctx/-/unctx-3.0.0.tgz",
-            "integrity": "sha512-DoXdZVeyi2jyEsn86i8MO5RTItm1kffUkH9/+DQORn3Q688AMOy2551CIl6AdGL2UpwD675wtbNOl75wIQN/uA==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/unctx/-/unctx-3.0.1.tgz",
+            "integrity": "sha512-5RAt2etv7g362RXyd33R82gm9u/kbtQlpoaOs9Bgm4E32GRMJ0xjbZyvdxUTmiuHk3V1IQb1aUNrp5IWY+JaWw==",
             "license": "MIT",
             "peerDependencies": {
                 "magic-string": ">=0.30.21",
@@ -19818,9 +19965,9 @@
             }
         },
         "node_modules/undici": {
-            "version": "6.28.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
-            "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
+            "version": "6.28.1",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.1.tgz",
+            "integrity": "sha512-zWpdTVD54H48CIybL0rWQ3ukpb9d23wM7eH5RtfdmeP70cWHNjtfo7P4vZX+5CoDcO53J4Pu5uXp7lNfjc6DRA==",
             "license": "MIT",
             "engines": {
                 "node": ">=18.17"
@@ -19914,9 +20061,9 @@
             }
         },
         "node_modules/unifont/node_modules/undici": {
-            "version": "8.10.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
-            "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
+            "version": "8.10.2",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.2.tgz",
+            "integrity": "sha512-/y4/bH9YNU5hi9NIrpOuvGXFcxrj3CMrV+/AYpowAYTpHn8gX/XPFjNy766FPoYY0miQhdW977JFWKGNhBdwyQ==",
             "license": "MIT",
             "engines": {
                 "node": ">=22.19.0"
@@ -19978,18 +20125,6 @@
             "license": "MIT",
             "dependencies": {
                 "@types/estree": "^1.0.0"
-            }
-        },
-        "node_modules/unimport/node_modules/strip-literal": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-4.0.0.tgz",
-            "integrity": "sha512-PaqAvfUZKBwc/SLmNZtHmzK+v19Z4O4eS3cKPeGvbIv/U3pnyEq4Tuw3/4v/FwfM8VQaEawsyCcOQ0P+kpwWWw==",
-            "license": "MIT",
-            "dependencies": {
-                "js-tokens": "^10.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/antfu"
             }
         },
         "node_modules/unist-builder": {
@@ -20424,9 +20559,9 @@
             }
         },
         "node_modules/update-browserslist-db": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.1.tgz",
-            "integrity": "sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.2.tgz",
+            "integrity": "sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -20661,15 +20796,15 @@
             }
         },
         "node_modules/vite": {
-            "version": "8.2.1",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.1.tgz",
-            "integrity": "sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==",
+            "version": "8.2.2",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.2.tgz",
+            "integrity": "sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q==",
             "license": "MIT",
             "dependencies": {
                 "lightningcss": "^1.33.0",
                 "picomatch": "^4.0.5",
-                "postcss": "^8.5.25",
-                "rolldown": "~1.2.1",
+                "postcss": "^8.5.26",
+                "rolldown": "~1.2.4",
                 "tinyglobby": "^0.2.17"
             },
             "bin": {
@@ -20686,7 +20821,7 @@
             },
             "peerDependencies": {
                 "@types/node": "^20.19.0 || >=22.12.0",
-                "@vitejs/devtools": "^0.4.0",
+                "@vitejs/devtools": "^0.4.0 || ^0.5.0",
                 "esbuild": "^0.27.0 || ^0.28.0",
                 "jiti": ">=1.21.0",
                 "less": "^4.0.0",
@@ -21243,22 +21378,22 @@
             }
         },
         "node_modules/vscode-uri": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
-            "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.2.0.tgz",
+            "integrity": "sha512-m2gXo3bn0G1kT9InzMf07fTbqMbGtyckj3bH5ktLO+1Ssv+yiATZ4dhwaQv9UZWxJh6E9IFGnQyjgWVDWVBDrg==",
             "license": "MIT"
         },
         "node_modules/vue": {
-            "version": "3.5.41",
-            "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.41.tgz",
-            "integrity": "sha512-2laE0p+aK+/AOPG/XL/WepOs/GlK755LJ1XECi9kDUrz1FKNw8rb2Xzlw9JS1rqEV55nb0ttsKxVlTCcd+R5cg==",
+            "version": "3.5.42",
+            "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.42.tgz",
+            "integrity": "sha512-4RyHQTbQvOPs3MfvUO1Sg0YRrKNnA0mAVtvpd12Tg1fKDN7OHBUl1IqSn8zGJjK9nI3NkNp8cgTpVrSZC5TTcA==",
             "license": "MIT",
             "dependencies": {
-                "@vue/compiler-dom": "3.5.41",
-                "@vue/compiler-sfc": "3.5.41",
-                "@vue/runtime-dom": "3.5.41",
-                "@vue/server-renderer": "3.5.41",
-                "@vue/shared": "3.5.41"
+                "@vue/compiler-dom": "3.5.42",
+                "@vue/compiler-sfc": "3.5.42",
+                "@vue/runtime-dom": "3.5.42",
+                "@vue/server-renderer": "3.5.42",
+                "@vue/shared": "3.5.42"
             },
             "peerDependencies": {
                 "typescript": "*"
@@ -21279,13 +21414,13 @@
             }
         },
         "node_modules/vue-component-meta": {
-            "version": "3.3.9",
-            "resolved": "https://registry.npmjs.org/vue-component-meta/-/vue-component-meta-3.3.9.tgz",
-            "integrity": "sha512-4u1VmMVjqs9BbKaISBZD7b+dNdqFteh5BYN8xVaXkjjJ66no1sRtDnS6aSs5/P5AzQQGPw10snHTf/z3HpBn2w==",
+            "version": "3.3.11",
+            "resolved": "https://registry.npmjs.org/vue-component-meta/-/vue-component-meta-3.3.11.tgz",
+            "integrity": "sha512-fskQZaIFOifwB4x+/J24795yvezOJ1TKaqn97/4PHybyvXpDNdcKn3oTcPrw6HnNoZWe343A+TiCFOcFv1/SuQ==",
             "license": "MIT",
             "dependencies": {
                 "@volar/typescript": "2.4.28",
-                "@vue/language-core": "3.3.9",
+                "@vue/language-core": "3.3.11",
                 "path-browserify": "^1.0.1"
             },
             "peerDependencies": {
@@ -21298,9 +21433,9 @@
             }
         },
         "node_modules/vue-component-type-helpers": {
-            "version": "3.3.10",
-            "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-3.3.10.tgz",
-            "integrity": "sha512-t7IQivQ3oD4D01b7s7a9AWzHAcr3DGBIa/1jZREsFQJcFgSL92gqUkqNiHTYgzTt7QDuJa0I9wCeDwEtZICoBQ==",
+            "version": "3.3.11",
+            "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-3.3.11.tgz",
+            "integrity": "sha512-LwcxzeliO9fkQcpJG0PoX8X5kmAhKmH9wkpDLxNabwzkQ9Zeib2YVHwFV4pcWmMLfXVfjr/dSV+DaJ3cIPgSNA==",
             "license": "MIT"
         },
         "node_modules/vue-devtools-stub": {
@@ -21310,14 +21445,14 @@
             "license": "MIT"
         },
         "node_modules/vue-i18n": {
-            "version": "11.4.8",
-            "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-11.4.8.tgz",
-            "integrity": "sha512-0ULeHP6Z9CGvAm67S77ZEp41cfGXIREGL8qfhos2BMgcQQewtQcDKuojt6jjasAD/S8GwfTp2ySPmDSpwvrCMQ==",
+            "version": "11.4.10",
+            "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-11.4.10.tgz",
+            "integrity": "sha512-Lp+BjOxqzOY87DS6Z8KrQrpiTr9IN/Lt4kZEilwyXG2Wrx+AcU6IVsAW92HNXtVcn1HFFPV6ty41p9e/qDpyvg==",
             "license": "MIT",
             "dependencies": {
-                "@intlify/core-base": "11.4.8",
-                "@intlify/devtools-types": "11.4.8",
-                "@intlify/shared": "11.4.8",
+                "@intlify/core-base": "11.4.10",
+                "@intlify/devtools-types": "11.4.10",
+                "@intlify/shared": "11.4.10",
                 "@vue/devtools-api": "^6.5.0"
             },
             "engines": {
@@ -21331,17 +21466,16 @@
             }
         },
         "node_modules/vue-router": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-5.2.0.tgz",
-            "integrity": "sha512-QAC5i0LEb1GLG0LXDQmHu8L7FX12j0KwU/JTKmLQUJMrn04gQdKP6Du+p0QwpHb3iy71vBlqnHQ8WAfOSAWhqw==",
+            "version": "5.3.1",
+            "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-5.3.1.tgz",
+            "integrity": "sha512-GDBZzgmILxA/kFnkFbJjQZdZ2QQbngnIMMuoUcjhZIfH1RGMaPjPwX5ASnV38qamuA9uhO0RDjSBHTDNG2uXyQ==",
             "license": "MIT",
             "dependencies": {
-                "@babel/generator": "^8.0.0",
                 "@vue-macros/common": "^3.1.3",
                 "@vue/devtools-api": "^8.1.5",
                 "ast-walker-scope": "^0.9.0",
                 "chokidar": "^5.0.0",
-                "json5": "^2.2.3",
+                "confbox": "^0.2.4",
                 "local-pkg": "^1.2.1",
                 "magic-string": "^0.30.21",
                 "mlly": "^1.8.2",
@@ -21352,8 +21486,7 @@
                 "scule": "^1.3.0",
                 "tinyglobby": "^0.2.17",
                 "unplugin": "^3.3.0",
-                "unplugin-utils": "^0.3.2",
-                "yaml": "^2.9.0"
+                "unplugin-utils": "^0.3.2"
             },
             "funding": {
                 "url": "https://github.com/sponsors/posva"
@@ -21378,69 +21511,6 @@
                 "vite": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/vue-router/node_modules/@babel/generator": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-8.0.0.tgz",
-            "integrity": "sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g==",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/parser": "^8.0.0",
-                "@babel/types": "^8.0.0",
-                "@jridgewell/gen-mapping": "^0.3.12",
-                "@jridgewell/trace-mapping": "^0.3.28",
-                "@types/jsesc": "^2.5.0",
-                "jsesc": "^3.0.2"
-            },
-            "engines": {
-                "node": "^22.18.0 || >=24.11.0"
-            }
-        },
-        "node_modules/vue-router/node_modules/@babel/helper-string-parser": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
-            "integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
-            "license": "MIT",
-            "engines": {
-                "node": "^22.18.0 || >=24.11.0"
-            }
-        },
-        "node_modules/vue-router/node_modules/@babel/helper-validator-identifier": {
-            "version": "8.0.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
-            "integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
-            "license": "MIT",
-            "engines": {
-                "node": "^22.18.0 || >=24.11.0"
-            }
-        },
-        "node_modules/vue-router/node_modules/@babel/parser": {
-            "version": "8.0.4",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.4.tgz",
-            "integrity": "sha512-srpptsAkEbbNIC/q8nT7o+m6CQe8CJUTV/t7MYc9NnWlgYVtHOb7JH6SorxMhN0kuRJjVqXbKClG6xSbPtzz+g==",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/types": "^8.0.4"
-            },
-            "bin": {
-                "parser": "bin/babel-parser.js"
-            },
-            "engines": {
-                "node": "^22.18.0 || >=24.11.0"
-            }
-        },
-        "node_modules/vue-router/node_modules/@babel/types": {
-            "version": "8.0.4",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
-            "integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-string-parser": "^8.0.0",
-                "@babel/helper-validator-identifier": "^8.0.4"
-            },
-            "engines": {
-                "node": "^22.18.0 || >=24.11.0"
             }
         },
         "node_modules/vue-router/node_modules/@vue/devtools-api": {
@@ -21917,9 +21987,9 @@
             }
         },
         "node_modules/zod": {
-            "version": "4.4.3",
-            "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-            "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+            "version": "4.5.4",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-4.5.4.tgz",
+            "integrity": "sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==",
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"

--- a/docs/package.json
+++ b/docs/package.json
@@ -15,7 +15,7 @@
         "@nuxt/ui": "^4.11.0",
         "@unhead/vue": "^3.4.0",
         "better-sqlite3": "^12.11.1",
-        "docus": "^5.12.3",
+        "docus": "^5.13.0",
         "nuxt": "^4.5.2",
         "typescript": "^7.0.2"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,30 +1,30 @@
 {
-    "name": "flowforge",
+    "name": "flowforge-review",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "devDependencies": {
                 "@awcodes/filament-plugin-purge": "^1.1.2",
-                "@tailwindcss/cli": "^4.1.10",
-                "@tailwindcss/forms": "^0.5.10",
-                "@tailwindcss/postcss": "^4.1.10",
-                "@tailwindcss/typography": "^0.5.16",
-                "esbuild": "^0.28.1",
+                "@tailwindcss/cli": "^4.3.3",
+                "@tailwindcss/forms": "^0.5.11",
+                "@tailwindcss/postcss": "^4.3.3",
+                "@tailwindcss/typography": "^0.5.20",
+                "esbuild": "^0.28.2",
                 "npm-run-all": "^4.1.5",
-                "postcss": "^8.5.25",
+                "postcss": "^8.5.28",
                 "postcss-nested": "^7.0.2",
                 "postcss-nesting": "^13.0.2",
-                "prettier": "^3.5.3",
-                "prettier-plugin-tailwindcss": "^0.6.12",
-                "sass": "^1.89.2",
-                "tailwindcss": "^4.1.10"
+                "prettier": "^3.9.6",
+                "prettier-plugin-tailwindcss": "^0.6.14",
+                "sass": "^1.104.0",
+                "tailwindcss": "^4.3.3"
             }
         },
         "node_modules/@alloc/quick-lru": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
-            "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.3.0.tgz",
+            "integrity": "sha512-U4+70Pc5ZS9osnCBCE5Jha/ciHM+Yp+CNMNC/7HvYbNRk1Ldd+f7qO65W5qfhu/TCv+/ozljlXXe9Nj8419DMA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -51,9 +51,9 @@
             }
         },
         "node_modules/@esbuild/aix-ppc64": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
-            "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+            "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
             "cpu": [
                 "ppc64"
             ],
@@ -68,9 +68,9 @@
             }
         },
         "node_modules/@esbuild/android-arm": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
-            "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+            "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
             "cpu": [
                 "arm"
             ],
@@ -85,9 +85,9 @@
             }
         },
         "node_modules/@esbuild/android-arm64": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
-            "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+            "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
             "cpu": [
                 "arm64"
             ],
@@ -102,9 +102,9 @@
             }
         },
         "node_modules/@esbuild/android-x64": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
-            "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+            "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
             "cpu": [
                 "x64"
             ],
@@ -119,9 +119,9 @@
             }
         },
         "node_modules/@esbuild/darwin-arm64": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
-            "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+            "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
             "cpu": [
                 "arm64"
             ],
@@ -136,9 +136,9 @@
             }
         },
         "node_modules/@esbuild/darwin-x64": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
-            "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+            "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
             "cpu": [
                 "x64"
             ],
@@ -153,9 +153,9 @@
             }
         },
         "node_modules/@esbuild/freebsd-arm64": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
-            "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+            "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
             "cpu": [
                 "arm64"
             ],
@@ -170,9 +170,9 @@
             }
         },
         "node_modules/@esbuild/freebsd-x64": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
-            "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+            "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
             "cpu": [
                 "x64"
             ],
@@ -187,9 +187,9 @@
             }
         },
         "node_modules/@esbuild/linux-arm": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
-            "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+            "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
             "cpu": [
                 "arm"
             ],
@@ -204,9 +204,9 @@
             }
         },
         "node_modules/@esbuild/linux-arm64": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
-            "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+            "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
             "cpu": [
                 "arm64"
             ],
@@ -221,9 +221,9 @@
             }
         },
         "node_modules/@esbuild/linux-ia32": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
-            "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+            "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
             "cpu": [
                 "ia32"
             ],
@@ -238,9 +238,9 @@
             }
         },
         "node_modules/@esbuild/linux-loong64": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
-            "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+            "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
             "cpu": [
                 "loong64"
             ],
@@ -255,9 +255,9 @@
             }
         },
         "node_modules/@esbuild/linux-mips64el": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
-            "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+            "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
             "cpu": [
                 "mips64el"
             ],
@@ -272,9 +272,9 @@
             }
         },
         "node_modules/@esbuild/linux-ppc64": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
-            "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+            "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
             "cpu": [
                 "ppc64"
             ],
@@ -289,9 +289,9 @@
             }
         },
         "node_modules/@esbuild/linux-riscv64": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
-            "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+            "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
             "cpu": [
                 "riscv64"
             ],
@@ -306,9 +306,9 @@
             }
         },
         "node_modules/@esbuild/linux-s390x": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
-            "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+            "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
             "cpu": [
                 "s390x"
             ],
@@ -323,9 +323,9 @@
             }
         },
         "node_modules/@esbuild/linux-x64": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
-            "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+            "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
             "cpu": [
                 "x64"
             ],
@@ -340,9 +340,9 @@
             }
         },
         "node_modules/@esbuild/netbsd-arm64": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
-            "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+            "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
             "cpu": [
                 "arm64"
             ],
@@ -357,9 +357,9 @@
             }
         },
         "node_modules/@esbuild/netbsd-x64": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
-            "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+            "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
             "cpu": [
                 "x64"
             ],
@@ -374,9 +374,9 @@
             }
         },
         "node_modules/@esbuild/openbsd-arm64": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
-            "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+            "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
             "cpu": [
                 "arm64"
             ],
@@ -391,9 +391,9 @@
             }
         },
         "node_modules/@esbuild/openbsd-x64": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
-            "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+            "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
             "cpu": [
                 "x64"
             ],
@@ -408,9 +408,9 @@
             }
         },
         "node_modules/@esbuild/openharmony-arm64": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
-            "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+            "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
             "cpu": [
                 "arm64"
             ],
@@ -425,9 +425,9 @@
             }
         },
         "node_modules/@esbuild/sunos-x64": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
-            "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+            "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
             "cpu": [
                 "x64"
             ],
@@ -442,9 +442,9 @@
             }
         },
         "node_modules/@esbuild/win32-arm64": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
-            "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+            "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
             "cpu": [
                 "arm64"
             ],
@@ -459,9 +459,9 @@
             }
         },
         "node_modules/@esbuild/win32-ia32": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
-            "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+            "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
             "cpu": [
                 "ia32"
             ],
@@ -476,9 +476,9 @@
             }
         },
         "node_modules/@esbuild/win32-x64": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
-            "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+            "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
             "cpu": [
                 "x64"
             ],
@@ -525,9 +525,9 @@
             }
         },
         "node_modules/@jridgewell/sourcemap-codec": {
-            "version": "1.5.5",
-            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
-            "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.6.0.tgz",
+            "integrity": "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==",
             "dev": true,
             "license": "MIT"
         },
@@ -543,17 +543,17 @@
             }
         },
         "node_modules/@parcel/watcher": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
-            "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.1.tgz",
+            "integrity": "sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg==",
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {
-                "detect-libc": "^2.0.3",
+                "detect-libc": "^1.0.3",
                 "is-glob": "^4.0.3",
-                "node-addon-api": "^7.0.0",
-                "picomatch": "^4.0.3"
+                "micromatch": "^4.0.5",
+                "node-addon-api": "^7.0.0"
             },
             "engines": {
                 "node": ">= 10.0.0"
@@ -563,25 +563,25 @@
                 "url": "https://opencollective.com/parcel"
             },
             "optionalDependencies": {
-                "@parcel/watcher-android-arm64": "2.5.6",
-                "@parcel/watcher-darwin-arm64": "2.5.6",
-                "@parcel/watcher-darwin-x64": "2.5.6",
-                "@parcel/watcher-freebsd-x64": "2.5.6",
-                "@parcel/watcher-linux-arm-glibc": "2.5.6",
-                "@parcel/watcher-linux-arm-musl": "2.5.6",
-                "@parcel/watcher-linux-arm64-glibc": "2.5.6",
-                "@parcel/watcher-linux-arm64-musl": "2.5.6",
-                "@parcel/watcher-linux-x64-glibc": "2.5.6",
-                "@parcel/watcher-linux-x64-musl": "2.5.6",
-                "@parcel/watcher-win32-arm64": "2.5.6",
-                "@parcel/watcher-win32-ia32": "2.5.6",
-                "@parcel/watcher-win32-x64": "2.5.6"
+                "@parcel/watcher-android-arm64": "2.5.1",
+                "@parcel/watcher-darwin-arm64": "2.5.1",
+                "@parcel/watcher-darwin-x64": "2.5.1",
+                "@parcel/watcher-freebsd-x64": "2.5.1",
+                "@parcel/watcher-linux-arm-glibc": "2.5.1",
+                "@parcel/watcher-linux-arm-musl": "2.5.1",
+                "@parcel/watcher-linux-arm64-glibc": "2.5.1",
+                "@parcel/watcher-linux-arm64-musl": "2.5.1",
+                "@parcel/watcher-linux-x64-glibc": "2.5.1",
+                "@parcel/watcher-linux-x64-musl": "2.5.1",
+                "@parcel/watcher-win32-arm64": "2.5.1",
+                "@parcel/watcher-win32-ia32": "2.5.1",
+                "@parcel/watcher-win32-x64": "2.5.1"
             }
         },
         "node_modules/@parcel/watcher-android-arm64": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.6.tgz",
-            "integrity": "sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==",
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.1.tgz",
+            "integrity": "sha512-KF8+j9nNbUN8vzOFDpRMsaKBHZ/mcjEjMToVMJOhTozkDonQFFrRcfdLWn6yWKCmJKmdVxSgHiYvTCef4/qcBA==",
             "cpu": [
                 "arm64"
             ],
@@ -600,9 +600,9 @@
             }
         },
         "node_modules/@parcel/watcher-darwin-arm64": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.6.tgz",
-            "integrity": "sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==",
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.1.tgz",
+            "integrity": "sha512-eAzPv5osDmZyBhou8PoF4i6RQXAfeKL9tjb3QzYuccXFMQU0ruIc/POh30ePnaOyD1UXdlKguHBmsTs53tVoPw==",
             "cpu": [
                 "arm64"
             ],
@@ -621,9 +621,9 @@
             }
         },
         "node_modules/@parcel/watcher-darwin-x64": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.6.tgz",
-            "integrity": "sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==",
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.1.tgz",
+            "integrity": "sha512-1ZXDthrnNmwv10A0/3AJNZ9JGlzrF82i3gNQcWOzd7nJ8aj+ILyW1MTxVk35Db0u91oD5Nlk9MBiujMlwmeXZg==",
             "cpu": [
                 "x64"
             ],
@@ -642,9 +642,9 @@
             }
         },
         "node_modules/@parcel/watcher-freebsd-x64": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.6.tgz",
-            "integrity": "sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==",
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.1.tgz",
+            "integrity": "sha512-SI4eljM7Flp9yPuKi8W0ird8TI/JK6CSxju3NojVI6BjHsTyK7zxA9urjVjEKJ5MBYC+bLmMcbAWlZ+rFkLpJQ==",
             "cpu": [
                 "x64"
             ],
@@ -663,13 +663,16 @@
             }
         },
         "node_modules/@parcel/watcher-linux-arm-glibc": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.6.tgz",
-            "integrity": "sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==",
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.1.tgz",
+            "integrity": "sha512-RCdZlEyTs8geyBkkcnPWvtXLY44BCeZKmGYRtSgtwwnHR4dxfHRG3gR99XdMEdQ7KeiDdasJwwvNSF5jKtDwdA==",
             "cpu": [
                 "arm"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -684,13 +687,16 @@
             }
         },
         "node_modules/@parcel/watcher-linux-arm-musl": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.6.tgz",
-            "integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.1.tgz",
+            "integrity": "sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==",
             "cpu": [
                 "arm"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -705,13 +711,16 @@
             }
         },
         "node_modules/@parcel/watcher-linux-arm64-glibc": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.6.tgz",
-            "integrity": "sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==",
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.1.tgz",
+            "integrity": "sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -726,13 +735,16 @@
             }
         },
         "node_modules/@parcel/watcher-linux-arm64-musl": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.6.tgz",
-            "integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.1.tgz",
+            "integrity": "sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -747,13 +759,16 @@
             }
         },
         "node_modules/@parcel/watcher-linux-x64-glibc": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.6.tgz",
-            "integrity": "sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==",
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.1.tgz",
+            "integrity": "sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -768,13 +783,16 @@
             }
         },
         "node_modules/@parcel/watcher-linux-x64-musl": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.6.tgz",
-            "integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.1.tgz",
+            "integrity": "sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -789,9 +807,9 @@
             }
         },
         "node_modules/@parcel/watcher-win32-arm64": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.6.tgz",
-            "integrity": "sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==",
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.1.tgz",
+            "integrity": "sha512-RFzklRvmc3PkjKjry3hLF9wD7ppR4AKcWNzH7kXR7GUe0Igb3Nz8fyPwtZCSquGrhU5HhUNDr/mKBqj7tqA2Vw==",
             "cpu": [
                 "arm64"
             ],
@@ -810,9 +828,9 @@
             }
         },
         "node_modules/@parcel/watcher-win32-ia32": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.6.tgz",
-            "integrity": "sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==",
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.1.tgz",
+            "integrity": "sha512-c2KkcVN+NJmuA7CGlaGD1qJh1cLfDnQsHjE89E60vUEMlqduHGCdCLJCID5geFVM0dOtA3ZiIO8BoEQmzQVfpQ==",
             "cpu": [
                 "ia32"
             ],
@@ -831,9 +849,9 @@
             }
         },
         "node_modules/@parcel/watcher-win32-x64": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.6.tgz",
-            "integrity": "sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==",
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.1.tgz",
+            "integrity": "sha512-9lHBdJITeNR++EvSQVUcaZoWupyHfXe1jZvGZ06O/5MflPcuPLtEphScIBL+AiCWBO46tDSHzWyD0uDmmZqsgA==",
             "cpu": [
                 "x64"
             ],
@@ -852,19 +870,19 @@
             }
         },
         "node_modules/@tailwindcss/cli": {
-            "version": "4.1.18",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/cli/-/cli-4.1.18.tgz",
-            "integrity": "sha512-sMZ+lZbDyxwjD2E0L7oRUjJ01Ffjtme5OtjvvnC+cV4CEDcbqzbp25TCpxHj6kWLU9+DlqJOiNgSOgctC2aZmg==",
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/cli/-/cli-4.3.3.tgz",
+            "integrity": "sha512-ZvS/n1ZHOBKcVlhkt8l5NNr1EDXk1NboYO5CYDOs6NUmvT9z6bzkwsosaJftY57T/3gWNzWMJzIXLodZC8ssdw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@parcel/watcher": "^2.5.1",
-                "@tailwindcss/node": "4.1.18",
-                "@tailwindcss/oxide": "4.1.18",
-                "enhanced-resolve": "^5.18.3",
+                "@parcel/watcher": "2.5.1",
+                "@tailwindcss/node": "4.3.3",
+                "@tailwindcss/oxide": "4.3.3",
+                "enhanced-resolve": "^5.24.1",
                 "mri": "^1.2.0",
                 "picocolors": "^1.1.1",
-                "tailwindcss": "4.1.18"
+                "tailwindcss": "4.3.3"
             },
             "bin": {
                 "tailwindcss": "dist/index.mjs"
@@ -884,49 +902,49 @@
             }
         },
         "node_modules/@tailwindcss/node": {
-            "version": "4.1.18",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.1.18.tgz",
-            "integrity": "sha512-DoR7U1P7iYhw16qJ49fgXUlry1t4CpXeErJHnQ44JgTSKMaZUdf17cfn5mHchfJ4KRBZRFA/Coo+MUF5+gOaCQ==",
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.3.tgz",
+            "integrity": "sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@jridgewell/remapping": "^2.3.4",
-                "enhanced-resolve": "^5.18.3",
-                "jiti": "^2.6.1",
-                "lightningcss": "1.30.2",
+                "@jridgewell/remapping": "^2.3.5",
+                "enhanced-resolve": "^5.24.1",
+                "jiti": "^2.7.0",
+                "lightningcss": "1.32.0",
                 "magic-string": "^0.30.21",
                 "source-map-js": "^1.2.1",
-                "tailwindcss": "4.1.18"
+                "tailwindcss": "4.3.3"
             }
         },
         "node_modules/@tailwindcss/oxide": {
-            "version": "4.1.18",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.1.18.tgz",
-            "integrity": "sha512-EgCR5tTS5bUSKQgzeMClT6iCY3ToqE1y+ZB0AKldj809QXk1Y+3jB0upOYZrn9aGIzPtUsP7sX4QQ4XtjBB95A==",
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.3.tgz",
+            "integrity": "sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">= 10"
+                "node": ">= 20"
             },
             "optionalDependencies": {
-                "@tailwindcss/oxide-android-arm64": "4.1.18",
-                "@tailwindcss/oxide-darwin-arm64": "4.1.18",
-                "@tailwindcss/oxide-darwin-x64": "4.1.18",
-                "@tailwindcss/oxide-freebsd-x64": "4.1.18",
-                "@tailwindcss/oxide-linux-arm-gnueabihf": "4.1.18",
-                "@tailwindcss/oxide-linux-arm64-gnu": "4.1.18",
-                "@tailwindcss/oxide-linux-arm64-musl": "4.1.18",
-                "@tailwindcss/oxide-linux-x64-gnu": "4.1.18",
-                "@tailwindcss/oxide-linux-x64-musl": "4.1.18",
-                "@tailwindcss/oxide-wasm32-wasi": "4.1.18",
-                "@tailwindcss/oxide-win32-arm64-msvc": "4.1.18",
-                "@tailwindcss/oxide-win32-x64-msvc": "4.1.18"
+                "@tailwindcss/oxide-android-arm64": "4.3.3",
+                "@tailwindcss/oxide-darwin-arm64": "4.3.3",
+                "@tailwindcss/oxide-darwin-x64": "4.3.3",
+                "@tailwindcss/oxide-freebsd-x64": "4.3.3",
+                "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.3",
+                "@tailwindcss/oxide-linux-arm64-gnu": "4.3.3",
+                "@tailwindcss/oxide-linux-arm64-musl": "4.3.3",
+                "@tailwindcss/oxide-linux-x64-gnu": "4.3.3",
+                "@tailwindcss/oxide-linux-x64-musl": "4.3.3",
+                "@tailwindcss/oxide-wasm32-wasi": "4.3.3",
+                "@tailwindcss/oxide-win32-arm64-msvc": "4.3.3",
+                "@tailwindcss/oxide-win32-x64-msvc": "4.3.3"
             }
         },
         "node_modules/@tailwindcss/oxide-android-arm64": {
-            "version": "4.1.18",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.1.18.tgz",
-            "integrity": "sha512-dJHz7+Ugr9U/diKJA0W6N/6/cjI+ZTAoxPf9Iz9BFRF2GzEX8IvXxFIi/dZBloVJX/MZGvRuFA9rqwdiIEZQ0Q==",
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.3.tgz",
+            "integrity": "sha512-Y85A2gmPSkl5Ve5qR86GL4HT509cFqQh1aes9p3sSkyTPwt0Pppf3GkwGe4JPACcRYjgJIEhQgM6dBClnr0NYw==",
             "cpu": [
                 "arm64"
             ],
@@ -937,13 +955,13 @@
                 "android"
             ],
             "engines": {
-                "node": ">= 10"
+                "node": ">= 20"
             }
         },
         "node_modules/@tailwindcss/oxide-darwin-arm64": {
-            "version": "4.1.18",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.1.18.tgz",
-            "integrity": "sha512-Gc2q4Qhs660bhjyBSKgq6BYvwDz4G+BuyJ5H1xfhmDR3D8HnHCmT/BSkvSL0vQLy/nkMLY20PQ2OoYMO15Jd0A==",
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.3.tgz",
+            "integrity": "sha512-BiaWatpBcERQFDlOjRDpIVXuFK5PJez5SA4JMg6VYZdBYU+qKfV/vqjcIs+IYmtitf1xYQZTwXvU/8y4lfZUGw==",
             "cpu": [
                 "arm64"
             ],
@@ -954,13 +972,13 @@
                 "darwin"
             ],
             "engines": {
-                "node": ">= 10"
+                "node": ">= 20"
             }
         },
         "node_modules/@tailwindcss/oxide-darwin-x64": {
-            "version": "4.1.18",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.1.18.tgz",
-            "integrity": "sha512-FL5oxr2xQsFrc3X9o1fjHKBYBMD1QZNyc1Xzw/h5Qu4XnEBi3dZn96HcHm41c/euGV+GRiXFfh2hUCyKi/e+yw==",
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.3.tgz",
+            "integrity": "sha512-fAeUqfV5ndhxRwai8cXGzdLvul9utWOmeTkv69unv4ZXixjn61Z+p9lCWdwOwA3TYboG3BwdVuN/RDjhBRl0mw==",
             "cpu": [
                 "x64"
             ],
@@ -971,13 +989,13 @@
                 "darwin"
             ],
             "engines": {
-                "node": ">= 10"
+                "node": ">= 20"
             }
         },
         "node_modules/@tailwindcss/oxide-freebsd-x64": {
-            "version": "4.1.18",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.1.18.tgz",
-            "integrity": "sha512-Fj+RHgu5bDodmV1dM9yAxlfJwkkWvLiRjbhuO2LEtwtlYlBgiAT4x/j5wQr1tC3SANAgD+0YcmWVrj8R9trVMA==",
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.3.tgz",
+            "integrity": "sha512-iyf5bV6+wnAlflVeEy7R25dupxTNECZN5QMI0qNT6eT+EgaGdZcKhGkr5SdoaWiLJ3spLqIY9VCeSGrwmtg4kw==",
             "cpu": [
                 "x64"
             ],
@@ -988,13 +1006,13 @@
                 "freebsd"
             ],
             "engines": {
-                "node": ">= 10"
+                "node": ">= 20"
             }
         },
         "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
-            "version": "4.1.18",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.1.18.tgz",
-            "integrity": "sha512-Fp+Wzk/Ws4dZn+LV2Nqx3IilnhH51YZoRaYHQsVq3RQvEl+71VGKFpkfHrLM/Li+kt5c0DJe/bHXK1eHgDmdiA==",
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.3.tgz",
+            "integrity": "sha512-aAYUprJAJQWWbRrPvtjdroZ56Md+JM8pMiopS6xGEwDfLhqj+2ver2p4nU4Mb3CRqcMmNBjo8KkUgcxhkzVQGQ==",
             "cpu": [
                 "arm"
             ],
@@ -1005,81 +1023,93 @@
                 "linux"
             ],
             "engines": {
-                "node": ">= 10"
+                "node": ">= 20"
             }
         },
         "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
-            "version": "4.1.18",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.1.18.tgz",
-            "integrity": "sha512-S0n3jboLysNbh55Vrt7pk9wgpyTTPD0fdQeh7wQfMqLPM/Hrxi+dVsLsPrycQjGKEQk85Kgbx+6+QnYNiHalnw==",
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.3.tgz",
+            "integrity": "sha512-nDxldcEENOxZRzC2uu9jrutZdAAQtb+8WWDCSnWL1zvBk1+FN+x6MtDViPB5AJMfttVCUhehGWus3XBPgatM/w==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ],
             "engines": {
-                "node": ">= 10"
+                "node": ">= 20"
             }
         },
         "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
-            "version": "4.1.18",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.1.18.tgz",
-            "integrity": "sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==",
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.3.tgz",
+            "integrity": "sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ],
             "engines": {
-                "node": ">= 10"
+                "node": ">= 20"
             }
         },
         "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
-            "version": "4.1.18",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.1.18.tgz",
-            "integrity": "sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==",
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.3.tgz",
+            "integrity": "sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ],
             "engines": {
-                "node": ">= 10"
+                "node": ">= 20"
             }
         },
         "node_modules/@tailwindcss/oxide-linux-x64-musl": {
-            "version": "4.1.18",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.1.18.tgz",
-            "integrity": "sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==",
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.3.tgz",
+            "integrity": "sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ],
             "engines": {
-                "node": ">= 10"
+                "node": ">= 20"
             }
         },
         "node_modules/@tailwindcss/oxide-wasm32-wasi": {
-            "version": "4.1.18",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.1.18.tgz",
-            "integrity": "sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==",
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.3.tgz",
+            "integrity": "sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==",
             "bundleDependencies": [
                 "@napi-rs/wasm-runtime",
                 "@emnapi/core",
@@ -1095,30 +1125,30 @@
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@emnapi/core": "^1.7.1",
-                "@emnapi/runtime": "^1.7.1",
-                "@emnapi/wasi-threads": "^1.1.0",
-                "@napi-rs/wasm-runtime": "^1.1.0",
-                "@tybys/wasm-util": "^0.10.1",
-                "tslib": "^2.4.0"
+                "@emnapi/core": "^1.11.1",
+                "@emnapi/runtime": "^1.11.1",
+                "@emnapi/wasi-threads": "^1.2.2",
+                "@napi-rs/wasm-runtime": "^1.1.4",
+                "@tybys/wasm-util": "^0.10.2",
+                "tslib": "^2.8.1"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
         "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
-            "version": "1.7.1",
+            "version": "1.11.1",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@emnapi/wasi-threads": "1.1.0",
+                "@emnapi/wasi-threads": "1.2.2",
                 "tslib": "^2.4.0"
             }
         },
         "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
-            "version": "1.7.1",
+            "version": "1.11.1",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -1128,7 +1158,7 @@
             }
         },
         "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
-            "version": "1.1.0",
+            "version": "1.2.2",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -1138,19 +1168,25 @@
             }
         },
         "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
-            "version": "1.1.0",
+            "version": "1.1.4",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@emnapi/core": "^1.7.1",
-                "@emnapi/runtime": "^1.7.1",
                 "@tybys/wasm-util": "^0.10.1"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
+            },
+            "peerDependencies": {
+                "@emnapi/core": "^1.7.1",
+                "@emnapi/runtime": "^1.7.1"
             }
         },
         "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
-            "version": "0.10.1",
+            "version": "0.10.2",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -1167,9 +1203,9 @@
             "optional": true
         },
         "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
-            "version": "4.1.18",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.18.tgz",
-            "integrity": "sha512-HjSA7mr9HmC8fu6bdsZvZ+dhjyGCLdotjVOgLA2vEqxEBZaQo9YTX4kwgEvPCpRh8o4uWc4J/wEoFzhEmjvPbA==",
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.3.tgz",
+            "integrity": "sha512-3rc292Ca2ceK6Ulcc/bAVnTs/3nDtoPhyEKlgPv+yQJQi/JS/AMJlqzxvlDacL1nekbrcf6bTqp/jV4qgnPxNQ==",
             "cpu": [
                 "arm64"
             ],
@@ -1180,13 +1216,13 @@
                 "win32"
             ],
             "engines": {
-                "node": ">= 10"
+                "node": ">= 20"
             }
         },
         "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
-            "version": "4.1.18",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.1.18.tgz",
-            "integrity": "sha512-bJWbyYpUlqamC8dpR7pfjA0I7vdF6t5VpUGMWRkXVE3AXgIZjYUYAK7II1GNaxR8J1SSrSrppRar8G++JekE3Q==",
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.3.tgz",
+            "integrity": "sha512-yJ0pwIVc/nYeGoV02WtsN8KYyLQv7kyI2wDnkezyJlGGjkd4QLwDGAwl47YpPJeuI0M0ObaXGSPjvWDPeTPggw==",
             "cpu": [
                 "x64"
             ],
@@ -1197,34 +1233,34 @@
                 "win32"
             ],
             "engines": {
-                "node": ">= 10"
+                "node": ">= 20"
             }
         },
         "node_modules/@tailwindcss/postcss": {
-            "version": "4.1.18",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.1.18.tgz",
-            "integrity": "sha512-Ce0GFnzAOuPyfV5SxjXGn0CubwGcuDB0zcdaPuCSzAa/2vII24JTkH+I6jcbXLb1ctjZMZZI6OjDaLPJQL1S0g==",
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.3.3.tgz",
+            "integrity": "sha512-JTSZZGQi1AyKirbLN3azmjVzef92tcX7h+iSqPdaeStyFpGpDlKvvpxeOE8njhbUanbRwr3z8DyzhICWnMtQeg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@alloc/quick-lru": "^5.2.0",
-                "@tailwindcss/node": "4.1.18",
-                "@tailwindcss/oxide": "4.1.18",
-                "postcss": "^8.4.41",
-                "tailwindcss": "4.1.18"
+                "@tailwindcss/node": "4.3.3",
+                "@tailwindcss/oxide": "4.3.3",
+                "postcss": "^8.5.16",
+                "tailwindcss": "4.3.3"
             }
         },
         "node_modules/@tailwindcss/typography": {
-            "version": "0.5.19",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.19.tgz",
-            "integrity": "sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==",
+            "version": "0.5.20",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.20.tgz",
+            "integrity": "sha512-hwbzQuNUfcPvbegQFatVPl/MY/tcM9KLl963hQ5laJKPh81TEZ1+dNG9PirGvcaDBkp+BCshExAyKVPW91dozw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "postcss-selector-parser": "6.0.10"
             },
             "peerDependencies": {
-                "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1"
+                "tailwindcss": ">=3.0.0 || >=4.0.0 || insiders"
             }
         },
         "node_modules/agent-base": {
@@ -1241,9 +1277,9 @@
             }
         },
         "node_modules/ansi-regex": {
-            "version": "6.2.2",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-            "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+            "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1339,14 +1375,14 @@
             }
         },
         "node_modules/axios": {
-            "version": "1.18.1",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
-            "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
+            "version": "1.20.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.20.0.tgz",
+            "integrity": "sha512-r8aOh8j9cGKpgQAqpzrUHnSIc6a59Y3Xf/cv8sy1DrHCkZHzQGEuoq1tARk6qSyDdtQGSDgpb9kFlruzPvrgwg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "follow-redirects": "^1.16.0",
-                "form-data": "^4.0.5",
+                "form-data": "^4.0.6",
                 "https-proxy-agent": "^5.0.1",
                 "proxy-from-env": "^2.1.0"
             }
@@ -1402,6 +1438,19 @@
                 "concat-map": "0.0.1"
             }
         },
+        "node_modules/braces": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+            "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fill-range": "^7.1.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/buffer": {
             "version": "6.0.3",
             "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
@@ -1428,15 +1477,15 @@
             }
         },
         "node_modules/call-bind": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
-            "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+            "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "call-bind-apply-helpers": "^1.0.0",
-                "es-define-property": "^1.0.0",
-                "get-intrinsic": "^1.2.4",
+                "call-bind-apply-helpers": "^1.0.2",
+                "es-define-property": "^1.0.1",
+                "get-intrinsic": "^1.3.0",
                 "set-function-length": "^1.2.2"
             },
             "engines": {
@@ -1491,16 +1540,16 @@
             }
         },
         "node_modules/chokidar": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-            "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+            "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "readdirp": "^4.0.1"
+                "readdirp": "^5.0.0"
             },
             "engines": {
-                "node": ">= 14.16.0"
+                "node": ">= 20.19.0"
             },
             "funding": {
                 "url": "https://paulmillr.com/funding/"
@@ -1758,13 +1807,16 @@
             }
         },
         "node_modules/detect-libc": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
-            "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+            "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
             "dev": true,
             "license": "Apache-2.0",
+            "bin": {
+                "detect-libc": "bin/detect-libc.js"
+            },
             "engines": {
-                "node": ">=8"
+                "node": ">=0.10"
             }
         },
         "node_modules/dunder-proto": {
@@ -1783,14 +1835,14 @@
             }
         },
         "node_modules/enhanced-resolve": {
-            "version": "5.18.4",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.4.tgz",
-            "integrity": "sha512-LgQMM4WXU3QI+SYgEc2liRgznaD5ojbmY3sb8LxyguVkIg5FxdpTkvk72te2R38/TGKxH634oLxXRGY6d7AP+Q==",
+            "version": "5.24.5",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.5.tgz",
+            "integrity": "sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "graceful-fs": "^4.2.4",
-                "tapable": "^2.2.0"
+                "tapable": "^2.3.3"
             },
             "engines": {
                 "node": ">=10.13.0"
@@ -1807,9 +1859,9 @@
             }
         },
         "node_modules/es-abstract": {
-            "version": "1.24.1",
-            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.1.tgz",
-            "integrity": "sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw==",
+            "version": "1.24.2",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.2.tgz",
+            "integrity": "sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1875,6 +1927,25 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/es-abstract-get": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/es-abstract-get/-/es-abstract-get-1.0.0.tgz",
+            "integrity": "sha512-6PMWXpdhshVvFp+FoWYs1EvG1Nj0tvk0dZM+XcK0xMEM1czRVcP6ohqPWHy6qPagSpC8j4+p89WXlT+xXJs/fg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "es-object-atoms": "^1.1.2",
+                "is-callable": "^1.2.7",
+                "object-inspect": "^1.13.4"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/es-define-property": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -1896,9 +1967,9 @@
             }
         },
         "node_modules/es-object-atoms": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-            "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+            "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1925,15 +1996,18 @@
             }
         },
         "node_modules/es-to-primitive": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
-            "integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
+            "version": "1.3.4",
+            "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.4.tgz",
+            "integrity": "sha512-yPDz7wqpg1/mmHLmS3tcfTfbw5f1eryXvyghYBffGdERwe+mV7ZcWzTR8LR17Kvqt3qfPurjlonmnq3MKXIOXw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
+                "es-abstract-get": "^1.0.0",
+                "es-define-property": "^1.0.1",
+                "es-errors": "^1.3.0",
                 "is-callable": "^1.2.7",
-                "is-date-object": "^1.0.5",
-                "is-symbol": "^1.0.4"
+                "is-date-object": "^1.1.0",
+                "is-symbol": "^1.1.1"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -1943,9 +2017,9 @@
             }
         },
         "node_modules/esbuild": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
-            "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+            "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
@@ -1956,32 +2030,32 @@
                 "node": ">=18"
             },
             "optionalDependencies": {
-                "@esbuild/aix-ppc64": "0.28.1",
-                "@esbuild/android-arm": "0.28.1",
-                "@esbuild/android-arm64": "0.28.1",
-                "@esbuild/android-x64": "0.28.1",
-                "@esbuild/darwin-arm64": "0.28.1",
-                "@esbuild/darwin-x64": "0.28.1",
-                "@esbuild/freebsd-arm64": "0.28.1",
-                "@esbuild/freebsd-x64": "0.28.1",
-                "@esbuild/linux-arm": "0.28.1",
-                "@esbuild/linux-arm64": "0.28.1",
-                "@esbuild/linux-ia32": "0.28.1",
-                "@esbuild/linux-loong64": "0.28.1",
-                "@esbuild/linux-mips64el": "0.28.1",
-                "@esbuild/linux-ppc64": "0.28.1",
-                "@esbuild/linux-riscv64": "0.28.1",
-                "@esbuild/linux-s390x": "0.28.1",
-                "@esbuild/linux-x64": "0.28.1",
-                "@esbuild/netbsd-arm64": "0.28.1",
-                "@esbuild/netbsd-x64": "0.28.1",
-                "@esbuild/openbsd-arm64": "0.28.1",
-                "@esbuild/openbsd-x64": "0.28.1",
-                "@esbuild/openharmony-arm64": "0.28.1",
-                "@esbuild/sunos-x64": "0.28.1",
-                "@esbuild/win32-arm64": "0.28.1",
-                "@esbuild/win32-ia32": "0.28.1",
-                "@esbuild/win32-x64": "0.28.1"
+                "@esbuild/aix-ppc64": "0.28.2",
+                "@esbuild/android-arm": "0.28.2",
+                "@esbuild/android-arm64": "0.28.2",
+                "@esbuild/android-x64": "0.28.2",
+                "@esbuild/darwin-arm64": "0.28.2",
+                "@esbuild/darwin-x64": "0.28.2",
+                "@esbuild/freebsd-arm64": "0.28.2",
+                "@esbuild/freebsd-x64": "0.28.2",
+                "@esbuild/linux-arm": "0.28.2",
+                "@esbuild/linux-arm64": "0.28.2",
+                "@esbuild/linux-ia32": "0.28.2",
+                "@esbuild/linux-loong64": "0.28.2",
+                "@esbuild/linux-mips64el": "0.28.2",
+                "@esbuild/linux-ppc64": "0.28.2",
+                "@esbuild/linux-riscv64": "0.28.2",
+                "@esbuild/linux-s390x": "0.28.2",
+                "@esbuild/linux-x64": "0.28.2",
+                "@esbuild/netbsd-arm64": "0.28.2",
+                "@esbuild/netbsd-x64": "0.28.2",
+                "@esbuild/openbsd-arm64": "0.28.2",
+                "@esbuild/openbsd-x64": "0.28.2",
+                "@esbuild/openharmony-arm64": "0.28.2",
+                "@esbuild/sunos-x64": "0.28.2",
+                "@esbuild/win32-arm64": "0.28.2",
+                "@esbuild/win32-ia32": "0.28.2",
+                "@esbuild/win32-x64": "0.28.2"
             }
         },
         "node_modules/escape-string-regexp": {
@@ -1992,6 +2066,19 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.8.0"
+            }
+        },
+        "node_modules/fill-range": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+            "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "to-regex-range": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/follow-redirects": {
@@ -2059,18 +2146,21 @@
             }
         },
         "node_modules/function.prototype.name": {
-            "version": "1.1.8",
-            "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
-            "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.2.0.tgz",
+            "integrity": "sha512-jObKIik1P2QjPHP5nz5BaOtUlfgS0fWo8IUByNXkM+o+02sJOi94em77GwJKQSJ3gfPHdgzLNrHc1uokV4P/ew==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.8",
-                "call-bound": "^1.0.3",
-                "define-properties": "^1.2.1",
+                "call-bind": "^1.0.9",
+                "call-bound": "^1.0.4",
+                "es-define-property": "^1.0.1",
+                "es-errors": "^1.3.0",
                 "functions-have-names": "^1.2.3",
-                "hasown": "^2.0.2",
-                "is-callable": "^1.2.7"
+                "has-property-descriptors": "^1.0.2",
+                "hasown": "^2.0.4",
+                "is-callable": "^1.2.7",
+                "is-document.all": "^1.0.0"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -2450,13 +2540,13 @@
             }
         },
         "node_modules/is-core-module": {
-            "version": "2.16.1",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
-            "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+            "version": "2.16.2",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+            "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "hasown": "^2.0.2"
+                "hasown": "^2.0.3"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -2492,6 +2582,22 @@
             "dependencies": {
                 "call-bound": "^1.0.2",
                 "has-tostringtag": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-document.all": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-document.all/-/is-document.all-1.0.0.tgz",
+            "integrity": "sha512-+XSoyS05OdBbhFuELhgTCpFNHkpBOJqtsZfUFFpe5QTw+9Sjbh8zitxhQkYAo6wV7e1Vb8cAPvpCk9jGam/82g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.4"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -2596,6 +2702,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-number": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.12.0"
             }
         },
         "node_modules/is-number-object": {
@@ -2788,9 +2904,9 @@
             "license": "ISC"
         },
         "node_modules/jiti": {
-            "version": "2.6.1",
-            "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
-            "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+            "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -2805,9 +2921,9 @@
             "license": "MIT"
         },
         "node_modules/lightningcss": {
-            "version": "1.30.2",
-            "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.30.2.tgz",
-            "integrity": "sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ==",
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+            "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
             "dev": true,
             "license": "MPL-2.0",
             "dependencies": {
@@ -2821,23 +2937,23 @@
                 "url": "https://opencollective.com/parcel"
             },
             "optionalDependencies": {
-                "lightningcss-android-arm64": "1.30.2",
-                "lightningcss-darwin-arm64": "1.30.2",
-                "lightningcss-darwin-x64": "1.30.2",
-                "lightningcss-freebsd-x64": "1.30.2",
-                "lightningcss-linux-arm-gnueabihf": "1.30.2",
-                "lightningcss-linux-arm64-gnu": "1.30.2",
-                "lightningcss-linux-arm64-musl": "1.30.2",
-                "lightningcss-linux-x64-gnu": "1.30.2",
-                "lightningcss-linux-x64-musl": "1.30.2",
-                "lightningcss-win32-arm64-msvc": "1.30.2",
-                "lightningcss-win32-x64-msvc": "1.30.2"
+                "lightningcss-android-arm64": "1.32.0",
+                "lightningcss-darwin-arm64": "1.32.0",
+                "lightningcss-darwin-x64": "1.32.0",
+                "lightningcss-freebsd-x64": "1.32.0",
+                "lightningcss-linux-arm-gnueabihf": "1.32.0",
+                "lightningcss-linux-arm64-gnu": "1.32.0",
+                "lightningcss-linux-arm64-musl": "1.32.0",
+                "lightningcss-linux-x64-gnu": "1.32.0",
+                "lightningcss-linux-x64-musl": "1.32.0",
+                "lightningcss-win32-arm64-msvc": "1.32.0",
+                "lightningcss-win32-x64-msvc": "1.32.0"
             }
         },
         "node_modules/lightningcss-android-arm64": {
-            "version": "1.30.2",
-            "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.30.2.tgz",
-            "integrity": "sha512-BH9sEdOCahSgmkVhBLeU7Hc9DWeZ1Eb6wNS6Da8igvUwAe0sqROHddIlvU06q3WyXVEOYDZ6ykBZQnjTbmo4+A==",
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+            "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
             "cpu": [
                 "arm64"
             ],
@@ -2856,9 +2972,9 @@
             }
         },
         "node_modules/lightningcss-darwin-arm64": {
-            "version": "1.30.2",
-            "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.30.2.tgz",
-            "integrity": "sha512-ylTcDJBN3Hp21TdhRT5zBOIi73P6/W0qwvlFEk22fkdXchtNTOU4Qc37SkzV+EKYxLouZ6M4LG9NfZ1qkhhBWA==",
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+            "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
             "cpu": [
                 "arm64"
             ],
@@ -2877,9 +2993,9 @@
             }
         },
         "node_modules/lightningcss-darwin-x64": {
-            "version": "1.30.2",
-            "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.30.2.tgz",
-            "integrity": "sha512-oBZgKchomuDYxr7ilwLcyms6BCyLn0z8J0+ZZmfpjwg9fRVZIR5/GMXd7r9RH94iDhld3UmSjBM6nXWM2TfZTQ==",
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+            "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
             "cpu": [
                 "x64"
             ],
@@ -2898,9 +3014,9 @@
             }
         },
         "node_modules/lightningcss-freebsd-x64": {
-            "version": "1.30.2",
-            "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.30.2.tgz",
-            "integrity": "sha512-c2bH6xTrf4BDpK8MoGG4Bd6zAMZDAXS569UxCAGcA7IKbHNMlhGQ89eRmvpIUGfKWNVdbhSbkQaWhEoMGmGslA==",
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+            "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
             "cpu": [
                 "x64"
             ],
@@ -2919,9 +3035,9 @@
             }
         },
         "node_modules/lightningcss-linux-arm-gnueabihf": {
-            "version": "1.30.2",
-            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.30.2.tgz",
-            "integrity": "sha512-eVdpxh4wYcm0PofJIZVuYuLiqBIakQ9uFZmipf6LF/HRj5Bgm0eb3qL/mr1smyXIS1twwOxNWndd8z0E374hiA==",
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+            "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
             "cpu": [
                 "arm"
             ],
@@ -2940,13 +3056,16 @@
             }
         },
         "node_modules/lightningcss-linux-arm64-gnu": {
-            "version": "1.30.2",
-            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.30.2.tgz",
-            "integrity": "sha512-UK65WJAbwIJbiBFXpxrbTNArtfuznvxAJw4Q2ZGlU8kPeDIWEX1dg3rn2veBVUylA2Ezg89ktszWbaQnxD/e3A==",
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+            "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -2961,13 +3080,16 @@
             }
         },
         "node_modules/lightningcss-linux-arm64-musl": {
-            "version": "1.30.2",
-            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.30.2.tgz",
-            "integrity": "sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==",
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+            "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -2982,13 +3104,16 @@
             }
         },
         "node_modules/lightningcss-linux-x64-gnu": {
-            "version": "1.30.2",
-            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.30.2.tgz",
-            "integrity": "sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==",
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+            "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -3003,13 +3128,16 @@
             }
         },
         "node_modules/lightningcss-linux-x64-musl": {
-            "version": "1.30.2",
-            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.30.2.tgz",
-            "integrity": "sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==",
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+            "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -3024,9 +3152,9 @@
             }
         },
         "node_modules/lightningcss-win32-arm64-msvc": {
-            "version": "1.30.2",
-            "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.30.2.tgz",
-            "integrity": "sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==",
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+            "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
             "cpu": [
                 "arm64"
             ],
@@ -3045,9 +3173,9 @@
             }
         },
         "node_modules/lightningcss-win32-x64-msvc": {
-            "version": "1.30.2",
-            "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.30.2.tgz",
-            "integrity": "sha512-5g1yc73p+iAkid5phb4oVFMB45417DkRevRbt/El/gKXJk4jid+vPFF/AXbxn05Aky8PapwzZrdJShv5C0avjw==",
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+            "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
             "cpu": [
                 "x64"
             ],
@@ -3063,6 +3191,16 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss/node_modules/detect-libc": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+            "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/load-json-file": {
@@ -3132,6 +3270,20 @@
             "dev": true,
             "engines": {
                 "node": ">= 0.10.0"
+            }
+        },
+        "node_modules/micromatch": {
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+            "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "braces": "^3.0.3",
+                "picomatch": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=8.6"
             }
         },
         "node_modules/mime-db": {
@@ -3208,9 +3360,9 @@
             "license": "MIT"
         },
         "node_modules/nanoid": {
-            "version": "3.3.16",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-            "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+            "version": "3.3.18",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+            "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
             "dev": true,
             "funding": [
                 {
@@ -3379,13 +3531,14 @@
             }
         },
         "node_modules/own-keys": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
-            "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.2.tgz",
+            "integrity": "sha512-19YVAg7T+WTrxggPukVq7DjTv6+PJ867TmhCvBsYwmbFCsZd344rq2Ld1p0wo8f8Qrrhgp82c6FJRqdXWtSEhg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "get-intrinsic": "^1.2.6",
+                "call-bound": "^1.0.4",
+                "get-intrinsic": "^1.3.0",
                 "object-keys": "^1.1.1",
                 "safe-push-apply": "^1.0.0"
             },
@@ -3448,13 +3601,13 @@
             "license": "ISC"
         },
         "node_modules/picomatch": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">=12"
+                "node": ">=8.6"
             },
             "funding": {
                 "url": "https://github.com/sponsors/jonschlinkert"
@@ -3494,9 +3647,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.25",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
-            "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
+            "version": "8.5.28",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.28.tgz",
+            "integrity": "sha512-RRuzqDtt5Y9h3quz5hWhK+TPnsmVs6WwSU6LkJMeY4HstUEDuYTG8UJSdawMRzmzAtV+KEoG8N3Qg2qLy5vM/A==",
             "dev": true,
             "funding": [
                 {
@@ -3514,7 +3667,7 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "nanoid": "^3.3.16",
+                "nanoid": "^3.3.18",
                 "picocolors": "^1.1.1",
                 "source-map-js": "^1.2.1"
             },
@@ -3549,9 +3702,9 @@
             }
         },
         "node_modules/postcss-nested/node_modules/postcss-selector-parser": {
-            "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
-            "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+            "version": "7.1.6",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.6.tgz",
+            "integrity": "sha512-7qASPzhKF2l2KLboRZux8CCTRMdGiV08vWmyKzPz22qZ7ZjQBOeY7rNzNoCLSUiftJ7HUq0GERHmxw/t0dCdMw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3637,9 +3790,9 @@
             }
         },
         "node_modules/postcss-nesting/node_modules/postcss-selector-parser": {
-            "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
-            "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+            "version": "7.1.6",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.6.tgz",
+            "integrity": "sha512-7qASPzhKF2l2KLboRZux8CCTRMdGiV08vWmyKzPz22qZ7ZjQBOeY7rNzNoCLSUiftJ7HUq0GERHmxw/t0dCdMw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3665,9 +3818,9 @@
             }
         },
         "node_modules/prettier": {
-            "version": "3.8.1",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
-            "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+            "version": "3.9.6",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+            "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -3808,13 +3961,13 @@
             }
         },
         "node_modules/readdirp": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-            "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.1.1.tgz",
+            "integrity": "sha512-Kko+Y5XQ6fM+Ce3dq3m9YGxnacYZYl9cA1wZjaF3Vbry2L3i1qVg8+CAgNPsXRArPMUMCaOR7oa9Nqntc43JKA==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">= 14.18.0"
+                "node": ">= 20.19.0"
             },
             "funding": {
                 "type": "individual",
@@ -3866,12 +4019,13 @@
             }
         },
         "node_modules/resolve": {
-            "version": "1.22.11",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
-            "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+            "version": "1.22.12",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+            "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
+                "es-errors": "^1.3.0",
                 "is-core-module": "^2.16.1",
                 "path-parse": "^1.0.7",
                 "supports-preserve-symlinks-flag": "^1.0.0"
@@ -3904,15 +4058,15 @@
             }
         },
         "node_modules/safe-array-concat": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
-            "integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.4.tgz",
+            "integrity": "sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.8",
-                "call-bound": "^1.0.2",
-                "get-intrinsic": "^1.2.6",
+                "call-bind": "^1.0.9",
+                "call-bound": "^1.0.4",
+                "get-intrinsic": "^1.3.0",
                 "has-symbols": "^1.1.0",
                 "isarray": "^2.0.5"
             },
@@ -3980,21 +4134,21 @@
             }
         },
         "node_modules/sass": {
-            "version": "1.97.3",
-            "resolved": "https://registry.npmjs.org/sass/-/sass-1.97.3.tgz",
-            "integrity": "sha512-fDz1zJpd5GycprAbu4Q2PV/RprsRtKC/0z82z0JLgdytmcq0+ujJbJ/09bPGDxCLkKY3Np5cRAOcWiVkLXJURg==",
+            "version": "1.104.0",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.104.0.tgz",
+            "integrity": "sha512-btHMApW2bgolvClhRW8AlQJzgI9lUB3pPSofBQQT+E46GWvf9o0TVQ13SYv5riWZVFyPN+JNz3TKW9XhBlc10w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "chokidar": "^4.0.0",
-                "immutable": "^5.0.2",
+                "chokidar": "^5.0.0",
+                "immutable": "^5.1.5",
                 "source-map-js": ">=0.6.2 <2.0.0"
             },
             "bin": {
                 "sass": "sass.js"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=20.19.0"
             },
             "optionalDependencies": {
                 "@parcel/watcher": "^2.4.1"
@@ -4096,15 +4250,15 @@
             }
         },
         "node_modules/side-channel": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-            "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+            "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
-                "object-inspect": "^1.13.3",
-                "side-channel-list": "^1.0.0",
+                "object-inspect": "^1.13.4",
+                "side-channel-list": "^1.0.1",
                 "side-channel-map": "^1.0.1",
                 "side-channel-weakmap": "^1.0.2"
             },
@@ -4116,14 +4270,14 @@
             }
         },
         "node_modules/side-channel-list": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-            "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+            "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
-                "object-inspect": "^1.13.3"
+                "object-inspect": "^1.13.4"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -4218,9 +4372,9 @@
             }
         },
         "node_modules/spdx-license-ids": {
-            "version": "3.0.22",
-            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.22.tgz",
-            "integrity": "sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ==",
+            "version": "3.0.23",
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
+            "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
             "dev": true,
             "license": "CC0-1.0"
         },
@@ -4284,19 +4438,20 @@
             }
         },
         "node_modules/string.prototype.trim": {
-            "version": "1.2.10",
-            "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
-            "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
+            "version": "1.2.11",
+            "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.11.tgz",
+            "integrity": "sha512-PwvK7BU+CMTJGYQCTZb5RWXIML92lftJLhQz1tBzgKiqGxJaMlBAa48POXaNAC2s4y8jr3EFqrkF9+44neS46w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.8",
-                "call-bound": "^1.0.2",
+                "call-bind": "^1.0.9",
+                "call-bound": "^1.0.4",
                 "define-data-property": "^1.1.4",
                 "define-properties": "^1.2.1",
-                "es-abstract": "^1.23.5",
-                "es-object-atoms": "^1.0.0",
-                "has-property-descriptors": "^1.0.2"
+                "es-abstract": "^1.24.2",
+                "es-object-atoms": "^1.1.2",
+                "has-property-descriptors": "^1.0.2",
+                "safe-regex-test": "^1.1.0"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -4306,16 +4461,16 @@
             }
         },
         "node_modules/string.prototype.trimend": {
-            "version": "1.0.9",
-            "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
-            "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.10.tgz",
+            "integrity": "sha512-2+3aDAOmPTmuFwjDnmJG2ctEkQKVki7vOSqaxkv42Mowj1V6PnvuwFCRrR5lChUux1TBskPjfkeTOhqczDMxTw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.8",
-                "call-bound": "^1.0.2",
+                "call-bind": "^1.0.9",
+                "call-bound": "^1.0.4",
                 "define-properties": "^1.2.1",
-                "es-object-atoms": "^1.0.0"
+                "es-object-atoms": "^1.1.2"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -4343,13 +4498,13 @@
             }
         },
         "node_modules/strip-ansi": {
-            "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-            "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+            "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "ansi-regex": "^6.0.1"
+                "ansi-regex": "^6.2.2"
             },
             "engines": {
                 "node": ">=12"
@@ -4395,16 +4550,16 @@
             }
         },
         "node_modules/tailwindcss": {
-            "version": "4.1.18",
-            "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
-            "integrity": "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==",
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.3.tgz",
+            "integrity": "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/tapable": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
-            "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+            "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -4413,6 +4568,19 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/webpack"
+            }
+        },
+        "node_modules/to-regex-range": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+            "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-number": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=8.0"
             }
         },
         "node_modules/typed-array-buffer": {
@@ -4473,18 +4641,18 @@
             }
         },
         "node_modules/typed-array-length": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz",
-            "integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.8.tgz",
+            "integrity": "sha512-phPGCwqr2+Qo0fwniCE8e4pKnGu/yFb5nD5Y8bf0EEeiI5GklnACYA9GFy/DrAeRrKHXvHn+1SUsOWgJp6RO+g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.7",
-                "for-each": "^0.3.3",
-                "gopd": "^1.0.1",
-                "is-typed-array": "^1.1.13",
-                "possible-typed-array-names": "^1.0.0",
-                "reflect.getprototypeof": "^1.0.6"
+                "call-bind": "^1.0.9",
+                "for-each": "^0.3.5",
+                "gopd": "^1.2.0",
+                "is-typed-array": "^1.1.15",
+                "possible-typed-array-names": "^1.1.0",
+                "reflect.getprototypeof": "^1.0.10"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -4621,14 +4789,14 @@
             }
         },
         "node_modules/which-typed-array": {
-            "version": "1.1.20",
-            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
-            "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+            "version": "1.1.22",
+            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+            "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "available-typed-arrays": "^1.0.7",
-                "call-bind": "^1.0.8",
+                "call-bind": "^1.0.9",
                 "call-bound": "^1.0.4",
                 "for-each": "^0.3.5",
                 "get-proto": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -7,18 +7,18 @@
     },
     "devDependencies": {
         "@awcodes/filament-plugin-purge": "^1.1.2",
-        "@tailwindcss/cli": "^4.1.10",
-        "@tailwindcss/forms": "^0.5.10",
-        "@tailwindcss/postcss": "^4.1.10",
-        "@tailwindcss/typography": "^0.5.16",
-        "esbuild": "^0.28.1",
+        "@tailwindcss/cli": "^4.3.3",
+        "@tailwindcss/forms": "^0.5.11",
+        "@tailwindcss/postcss": "^4.3.3",
+        "@tailwindcss/typography": "^0.5.20",
+        "esbuild": "^0.28.2",
         "npm-run-all": "^4.1.5",
-        "postcss": "^8.5.25",
+        "postcss": "^8.5.28",
         "postcss-nested": "^7.0.2",
         "postcss-nesting": "^13.0.2",
-        "prettier": "^3.5.3",
-        "prettier-plugin-tailwindcss": "^0.6.12",
-        "sass": "^1.89.2",
-        "tailwindcss": "^4.1.10"
+        "prettier": "^3.9.6",
+        "prettier-plugin-tailwindcss": "^0.6.14",
+        "sass": "^1.104.0",
+        "tailwindcss": "^4.3.3"
     }
 }


### PR DESCRIPTION
Refresh Composer development requirements and both npm dependency trees before the next release. The root npm audit now reports zero vulnerabilities.

- Update Tailwind CSS to 4.3.3, PostCSS to 8.5.28, esbuild to 0.28.2, Docus to 5.13.0, and other compatible dependencies.
- Refresh both npm lockfiles, including patched nanoid 3.3.18 and postcss-selector-parser 7.1.6.
- Preserve PHP 8.3, Filament 5, and Laravel 12/13 support. Composer runtime ranges already resolve current compatible versions and remain unchanged.
- Retain both Pest 4/5 and Testbench 10/11 development paths. Composer lockfiles remain untracked under the existing library policy.
- Keep better-sqlite3 on 12.x for Docus's peer requirement. Leave breaking PostCSS plugin and Prettier plugin upgrades outside this compatibility update.

Validation:

- PHP 8.3 / Laravel 12 and PHP 8.5 / Laravel 13: 176 tests pass, with 20,723 assertions per environment.
- Composer validation passes; Composer and both npm audits report zero vulnerabilities.
- Clean npm installs and dependency-tree checks pass in both directories on Node 24.
- JavaScript bundle builds without changing the distributed artifact; documentation generation prerenders 47 routes successfully.
- Pint passes. PHPStan reports the same seven existing errors as the base commit, with no new errors or suppressions.
