### PR TITLE
chore: simplify Composer version constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,24 +27,24 @@
         "filament/schemas": "^5.0",
         "filament/support": "^5.0",
         "filament/tables": "^5.0",
-        "spatie/laravel-package-tools": "^1.15.0"
+        "spatie/laravel-package-tools": "^1.15"
     },
     "suggest": {
         "filament/filament": "Required for BoardPage, BoardResourcePage, and FlowforgePlugin panel integration (^5.0)"
     },
     "require-dev": {
-        "filament/filament": "^5.7.8",
+        "filament/filament": "^5.7",
         "larastan/larastan": "^3.11",
-        "laravel/pint": "^1.30.5",
-        "nunomaduro/collision": "^8.9.5",
+        "laravel/pint": "^1.30",
+        "nunomaduro/collision": "^8.9",
         "orchestra/testbench": "^10.11|^11.2",
-        "pestphp/pest": "^4.7.8|^5.1.3",
-        "pestphp/pest-plugin-arch": "^4.0.2|^5.0",
-        "pestphp/pest-plugin-laravel": "^4.1|^5.0.1",
-        "phpstan/extension-installer": "^1.4.3",
-        "phpstan/phpstan-deprecation-rules": "^2.0.5",
-        "phpstan/phpstan-phpunit": "^2.0.18",
-        "spatie/laravel-ray": "^1.43.9"
+        "pestphp/pest": "^4.7|^5.1",
+        "pestphp/pest-plugin-arch": "^4.0|^5.0",
+        "pestphp/pest-plugin-laravel": "^4.1|^5.0",
+        "phpstan/extension-installer": "^1.4",
+        "phpstan/phpstan-deprecation-rules": "^2.0",
+        "phpstan/phpstan-phpunit": "^2.0",
+        "spatie/laravel-ray": "^1.43"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Use major.minor caret constraints for Composer dependencies, including `filament/filament: ^5.7` instead of `^5.7.8`.

This follows the common notation in [Spatie's package tools](https://github.com/spatie/laravel-package-tools/blob/main/composer.json) and [Filament Support](https://github.com/filamentphp/filament/blob/5.x/packages/support/composer.json).
Both projects also use patch-specific constraints where needed. Three-part constraints are valid Composer syntax, but they set a more restrictive minimum.

The changes lower development patch minimums while preserving supported major and minor lines. `spatie/laravel-package-tools: ^1.15` is equivalent to `^1.15.0`.
Runtime compatibility and npm dependencies remain unchanged.

Validation:

- Composer validation passes; audited installations report zero vulnerabilities.
- PHP 8.5 / Laravel 13 / Filament 5.7.8: 176 tests pass, with 20,723 assertions.
- PHP 8.3 / Laravel 12 / Filament 5.7.6: 176 tests pass, with 20,723 assertions.
- Pint passes. PHPStan reports the same seven existing errors, with no new errors or suppressions.

The broader `^5.7` range also matches older vulnerable patches. Composer blocked the attempted 5.7.0 installation with its existing advisory protection.
The older-version test therefore uses 5.7.6, which contains the [MFA security fix](https://github.com/filamentphp/filament/security/advisories/GHSA-r3j6-gpjw-qfjr). No advisory checks were disabled.
