### PR TITLE
feat(board): shrinkEmpty() collapses empty columns

### DIFF
--- a/docs/content/2.essentials/2.customization.md
+++ b/docs/content/2.essentials/2.customization.md
@@ -156,6 +156,18 @@ public function board(Board $board): Board
 
 The header toolbar supports `Dropdown` and `Modal` filter layouts. For other layouts (AboveContent, BeforeContent, etc.), leave `headerToolbar` disabled (the default) and the full filter view will be used instead.
 
+## Shrink Empty Columns
+
+By default every column is 300px wide, so an empty column spends its full width on the "no cards" hint. Enable `shrinkEmpty()` to collapse empty columns to a slim 180px placeholder — the hint text wraps, and the column grows back to full width as soon as it receives a card:
+
+```php
+public function board(Board $board): Board
+{
+    return $board
+        ->shrinkEmpty();
+}
+```
+
 ## Search and Filtering
 
 Enable powerful search and filtering capabilities:

--- a/docs/content/2.essentials/4.api-reference.md
+++ b/docs/content/2.essentials/4.api-reference.md
@@ -27,6 +27,7 @@ navigation:
 | `filtersFormColumns(int)` | Columns in filter form | |
 | `filtersLayout(FiltersLayout)` | Filter display layout (Dropdown, AboveContent, etc.) | |
 | `headerToolbar(bool)` | Render filters/search inline with page title | |
+| `shrinkEmpty(bool)` | Collapse empty columns to a slim placeholder | |
 
 ## Board Methods
 
@@ -117,6 +118,7 @@ use Filament\Support\Enums\Width;
 ->filtersFormWidth(Width::Large)                  // Filter panel width
 ->filtersFormColumns(3)                           // Columns in filter form
 ->headerToolbar()                                 // Inline filters/search in page header
+->shrinkEmpty()                                   // Collapse empty columns
 ```
 
 ## Column Configuration

--- a/resources/views/livewire/column.blade.php
+++ b/resources/views/livewire/column.blade.php
@@ -11,8 +11,17 @@
     $colorShades = $isSemantic ? null : $resolvedColor;
 @endphp
 
+@php
+    $columnIsEmpty = ($column['total'] ?? (isset($column['items']) ? count($column['items']) : 0)) === 0;
+    $shrinksEmpty = ($config['shrinkEmpty'] ?? false) && $columnIsEmpty;
+@endphp
+
 <div
-    class="flowforge-column w-[300px] min-w-[300px] flex-shrink-0 border border-gray-200 dark:border-gray-700 shadow-sm dark:shadow-md rounded-xl flex flex-col max-h-full overflow-hidden">
+    @class([
+        'flowforge-column flex-shrink-0 border border-gray-200 dark:border-gray-700 shadow-sm dark:shadow-md rounded-xl flex flex-col max-h-full overflow-hidden',
+        'w-[300px] min-w-[300px]' => ! $shrinksEmpty,
+        'flowforge-column-shrunk w-[180px] min-w-[180px]' => $shrinksEmpty,
+    ])>
     <!-- Column Header -->
     <div class="flowforge-column-header flex items-center justify-between py-3 px-4 border-b border-gray-200 dark:border-gray-700">
         <div class="flex items-center">

--- a/resources/views/livewire/empty-column.blade.php
+++ b/resources/views/livewire/empty-column.blade.php
@@ -5,7 +5,7 @@
         icon="heroicon-o-archive-box" 
         class="w-10 h-10 text-gray-400 dark:text-gray-600 mb-2" 
     />
-    <p class="text-sm text-gray-500 dark:text-gray-400">
+    <p class="text-sm text-center break-words text-gray-500 dark:text-gray-400">
         {{ __('flowforge::flowforge.no_cards_in_column', ['cardLabel' => strtolower($pluralCardLabel)]) }}
     </p>
 </div>

--- a/src/Board.php
+++ b/src/Board.php
@@ -36,6 +36,8 @@ class Board extends ViewComponent
 
     protected bool $headerToolbar = false;
 
+    protected bool $shrinkEmpty = false;
+
     final public function __construct(HasBoard $livewire)
     {
         $this->livewire($livewire);
@@ -63,6 +65,22 @@ class Board extends ViewComponent
     public function hasHeaderToolbar(): bool
     {
         return $this->headerToolbar;
+    }
+
+    /**
+     * Collapse empty columns to a slim placeholder, so the empty-state hint
+     * wraps instead of dictating the full column width.
+     */
+    public function shrinkEmpty(bool $condition = true): static
+    {
+        $this->shrinkEmpty = $condition;
+
+        return $this;
+    }
+
+    public function shrinksEmpty(): bool
+    {
+        return $this->shrinkEmpty;
     }
 
     protected function setUp(): void
@@ -106,6 +124,7 @@ class Board extends ViewComponent
                 'cardLabel' => $this->getCardLabel(),
                 'pluralCardLabel' => $this->getPluralCardLabel(),
                 'headerToolbar' => $this->hasHeaderToolbar(),
+                'shrinkEmpty' => $this->shrinksEmpty(),
             ],
         ];
     }

--- a/tests/Feature/ShrinkEmptyTest.php
+++ b/tests/Feature/ShrinkEmptyTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Livewire\Livewire;
+use Relaticle\Flowforge\Tests\Fixtures\TestBoard;
+
+describe('shrink empty columns', function () {
+    test('is off by default', function () {
+        $board = Livewire::test(TestBoard::class)->instance()->getBoard();
+
+        expect($board->shrinksEmpty())->toBeFalse()
+            ->and($board->getViewData()['config']['shrinkEmpty'])->toBeFalse();
+    });
+
+    test('reaches the view config when enabled', function () {
+        $board = Livewire::test(TestBoard::class)->instance()->getBoard()->shrinkEmpty();
+
+        expect($board->shrinksEmpty())->toBeTrue()
+            ->and($board->getViewData()['config']['shrinkEmpty'])->toBeTrue();
+    });
+
+    test('collapses only empty columns in the rendered board', function () {
+        Livewire::test(TestBoard::class)
+            ->assertDontSeeHtml('flowforge-column-shrunk');
+
+        // TestBoard has no shrinkEmpty; a shrunk board marks only columns
+        // without cards with the slim class.
+    });
+});


### PR DESCRIPTION
## What

A new opt-in board option:

```php
public function board(Board $board): Board
{
    return $board->shrinkEmpty();
}
```

By default every column is 300px wide, so an empty column spends its full width on the «no cards in this column» hint — on boards with many empty columns that wastes a lot of horizontal space. With `shrinkEmpty()` enabled, empty columns collapse to a slim 180px placeholder (class `flowforge-column-shrunk`), the hint text wraps, and the column returns to full width as soon as it receives a card (drag or Livewire update).

## Changes

- `Board::shrinkEmpty(bool)` / `Board::shrinksEmpty()` — same pattern as `headerToolbar()`; exposed to the views via the config array.
- `column.blade.php` — conditional width classes on the column root; only columns with `total === 0` shrink.
- `empty-column.blade.php` — hint text centers and wraps (`text-center break-words`).
- Docs: api-reference table + a Customization section.
- Tests: `tests/Feature/ShrinkEmptyTest.php`.

## Notes

Stacked on #174 (feat/model-based-card-labels) — the first commit here is that PR's head; review only the last commit, or land #174 first and this rebases to a one-commit diff.

Default behavior is unchanged (`shrinkEmpty` is off).