### PR TITLE
chore(ci): stop persisting checkout credentials in pint and changelog

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -31,6 +31,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ steps.branch.outputs.name }}
+          persist-credentials: false
 
       - name: Update Changelog
         uses: stefanzweifel/changelog-updater-action@a938690fad7edf25368f37e43a1ed1b34303eb36 # v1.12.0

--- a/.github/workflows/pint.yml
+++ b/.github/workflows/pint.yml
@@ -22,7 +22,7 @@ jobs:
         uses: aglipanci/laravel-pint-action@36de00d5f5a8a4e12d443e01671daa12a18f4c79 # 2.6
 
       - name: Commit changes
-        if: github.ref_type == 'branch'
+        if: startsWith(github.ref, 'refs/heads/')
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/pint.yml
+++ b/.github/workflows/pint.yml
@@ -16,12 +16,22 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ github.head_ref }}
+          persist-credentials: false
 
       - name: Fix PHP code style issues
         uses: aglipanci/laravel-pint-action@36de00d5f5a8a4e12d443e01671daa12a18f4c79 # 2.6
 
       - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7.2.0
-        with:
-          commit_message: Fix styling
+        if: github.ref_type == 'branch'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if git diff --quiet; then
+            echo "No style changes to commit."
+            exit 0
+          fi
+
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git commit --all --message 'Fix styling'
+          git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:refs/heads/${GITHUB_REF_NAME}"


### PR DESCRIPTION
Closes the two open `zizmor/artipacked` code scanning alerts ([#8](https://github.com/relaticle/flowforge/security/code-scanning/8), [#1](https://github.com/relaticle/flowforge/security/code-scanning/1)).

Both workflows checked out with the default `persist-credentials`, which leaves a `contents: write` token in `.git/config` for every step that follows.

**`changelog.yml`** never needed it. `peter-evans/create-pull-request` configures its own token auth (`configureToken` in `git-config-helper.ts`) and removes it afterwards, and `changelog-updater-action` does no git operations. Adding `persist-credentials: false` is a no-op for behaviour.

**`pint.yml`** did need it: `stefanzweifel/git-auto-commit-action` pushes through the persisted credential and its README requires `persist-credentials: true`. So the commit step is now an explicit push. That keeps the write token out of `.git/config` while the third-party `aglipanci/laravel-pint-action` runs, which is the exposure the audit is about.

Two details in the new step:

- No `${{ }}` inside the `run:` body. The token comes in through `env:`, the rest uses the default `GITHUB_*` variables. Same reason the earlier `template-injection` alerts were fixed.
- `if: github.ref_type == 'branch'`, so a tag push can't try to push to `refs/heads/<tag>`.

The now-unused `ref: ${{ github.head_ref }}` was dropped. It is always empty on a `push` trigger.

## Verification

`zizmor` on `4.x`: 2 medium `artipacked`. On this branch: 0, with no new findings. The one remaining low `self-repository` in `release.yml` is pre-existing and untouched.

`actionlint` clean on both files. The new commit-and-push script was run against a local bare remote: it commits as `github-actions[bot]` and pushes when pint changes a file, and exits without pushing when it does not.