### PR TITLE
chore(ci): group dependabot security updates per ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,11 @@ updates:
       default-days: 7
     groups:
       github-actions:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      github-actions-security:
+        applies-to: security-updates
         patterns:
           - "*"
     labels:
@@ -25,10 +30,15 @@ updates:
       default-days: 7
     groups:
       npm-minor-patch:
+        applies-to: version-updates
         patterns:
           - "*"
         update-types:
           - "minor"
           - "patch"
+      npm-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
     labels:
       - "dependencies"


### PR DESCRIPTION
Part of the same cleanup as relaticle/custom-fields#217. This repository's workflows are already clean under zizmor, so only the Dependabot config changes.

`applies-to` defaults to `version-updates`, and both existing groups relied on that implicitly. Security updates were therefore ungrouped and arrived one pull request per advisory.

The npm group matters more than the others here: it is scoped to `minor` and `patch`, so a security fix that only exists in a new major was outside every group.

## Also done outside this PR

`allow_auto_merge` was off at the repo level, so `auto-merge.yml` could never merge a Dependabot PR. Now enabled. #172 is waiting on exactly that.

Caveat worth deciding separately: a merge enabled with `GITHUB_TOKEN` does not trigger `on: push` workflows, and `deploy-docs.yml` is `on: push` with `paths: docs/**`. Auto-merged docs bumps would stop redeploying the docs site until that uses a GitHub App token or a scheduled redeploy.